### PR TITLE
v1.2.0: Resolve QA findings

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ Add to your Claude Code settings or project `.mcp.json`:
 | `get_routine_adherence` | Completion rates and streak health |
 | `get_friction_analysis` | Predicted vs actual friction patterns |
 
-### Artifacts (8)
+### Artifacts (9)
 | Tool | Description |
 |------|-------------|
 | `create_artifact` | Store a reference document (CLAUDE.md, briefs, templates, etc.) |
@@ -183,8 +183,9 @@ Add to your Claude Code settings or project `.mcp.json`:
 | `tag_artifact` | Tag a document |
 | `untag_artifact` | Remove a tag from a document |
 | `list_artifact_tags` | List tags on a document |
+| `list_tagged_artifacts` | Find all artifacts with a specific tag |
 
-### Protocols (8)
+### Protocols (9)
 | Tool | Description |
 |------|-------------|
 | `create_protocol` | Define a step-by-step procedure |
@@ -195,8 +196,9 @@ Add to your Claude Code settings or project `.mcp.json`:
 | `tag_protocol` | Tag a protocol |
 | `untag_protocol` | Remove a tag from a protocol |
 | `list_protocol_tags` | List tags on a protocol |
+| `list_tagged_protocols` | Find all protocols with a specific tag |
 
-### Directives (9)
+### Directives (10)
 | Tool | Description |
 |------|-------------|
 | `create_directive` | Define a behavioral rule or guardrail |
@@ -208,6 +210,7 @@ Add to your Claude Code settings or project `.mcp.json`:
 | `tag_directive` | Tag a directive |
 | `untag_directive` | Remove a tag from a directive |
 | `list_directive_tags` | List tags on a directive |
+| `list_tagged_directives` | Find all directives with a specific tag |
 
 ### Skills (15)
 | Tool | Description |
@@ -228,7 +231,7 @@ Add to your Claude Code settings or project `.mcp.json`:
 | `link_skill_directive` | Associate a directive with a skill |
 | `unlink_skill_directive` | Remove directive association |
 
-### Batch Operations (12)
+### Batch Operations (9)
 | Tool | Description |
 |------|-------------|
 | `batch_create_tasks` | Create multiple tasks atomically (max 100) |
@@ -240,9 +243,6 @@ Add to your Claude Code settings or project `.mcp.json`:
 | `batch_tag_task` | Attach multiple tags to a task at once |
 | `batch_tag_activity` | Attach multiple tags to an activity at once |
 | `batch_tag_artifact` | Attach multiple tags to an artifact at once |
-| `list_tagged_artifacts` | Find all artifacts with a specific tag |
-| `list_tagged_protocols` | Find all protocols with a specific tag |
-| `list_tagged_directives` | Find all directives with a specific tag |
 
 ## Troubleshooting
 

--- a/mcp/tools/artifacts.py
+++ b/mcp/tools/artifacts.py
@@ -136,3 +136,9 @@ def register(mcp, api) -> None:
         """See which tags are on a document."""
         validate_uuid(artifact_id, "artifact_id")
         return await api.get(f"/api/artifacts/{artifact_id}/tags")
+
+    @mcp.tool()
+    async def list_tagged_artifacts(tag_id: str) -> list:
+        """Find all artifacts with a specific tag."""
+        validate_uuid(tag_id, "tag_id")
+        return await api.get(f"/api/tags/{tag_id}/artifacts")

--- a/mcp/tools/batch.py
+++ b/mcp/tools/batch.py
@@ -139,22 +139,3 @@ def register(mcp, api) -> None:
             json={"tag_ids": tag_ids},
         )
 
-    # --- Reverse Tag Lookups ---
-
-    @mcp.tool()
-    async def list_tagged_artifacts(tag_id: str) -> list:
-        """Find all artifacts with a specific tag."""
-        validate_uuid(tag_id, "tag_id")
-        return await api.get(f"/api/tags/{tag_id}/artifacts")
-
-    @mcp.tool()
-    async def list_tagged_protocols(tag_id: str) -> list:
-        """Find all protocols with a specific tag."""
-        validate_uuid(tag_id, "tag_id")
-        return await api.get(f"/api/tags/{tag_id}/protocols")
-
-    @mcp.tool()
-    async def list_tagged_directives(tag_id: str) -> list:
-        """Find all directives with a specific tag."""
-        validate_uuid(tag_id, "tag_id")
-        return await api.get(f"/api/tags/{tag_id}/directives")

--- a/mcp/tools/directives.py
+++ b/mcp/tools/directives.py
@@ -164,3 +164,9 @@ def register(mcp, api) -> None:
         """List tags on a directive."""
         validate_uuid(directive_id, "directive_id")
         return await api.get(f"/api/directives/{directive_id}/tags")
+
+    @mcp.tool()
+    async def list_tagged_directives(tag_id: str) -> list:
+        """Find all directives with a specific tag."""
+        validate_uuid(tag_id, "tag_id")
+        return await api.get(f"/api/tags/{tag_id}/directives")

--- a/mcp/tools/protocols.py
+++ b/mcp/tools/protocols.py
@@ -118,3 +118,9 @@ def register(mcp, api) -> None:
         """List tags on a protocol."""
         validate_uuid(protocol_id, "protocol_id")
         return await api.get(f"/api/protocols/{protocol_id}/tags")
+
+    @mcp.tool()
+    async def list_tagged_protocols(tag_id: str) -> list:
+        """Find all protocols with a specific tag."""
+        validate_uuid(tag_id, "tag_id")
+        return await api.get(f"/api/tags/{tag_id}/protocols")


### PR DESCRIPTION
## Summary
- Moves reverse tag lookup tools from batch.py to their entity modules, matching the established codebase pattern
- Updates README to reflect the reorganization

## Changes

**mcp/tools/batch.py** — Removed `list_tagged_artifacts`, `list_tagged_protocols`, and `list_tagged_directives` from the "Reverse Tag Lookups" section. The batch module now contains only batch create (6) and batch tag (3) tools. (#30)

**mcp/tools/artifacts.py** — Added `list_tagged_artifacts` tool, following the same pattern as `list_tagged_tasks` in tasks.py and `list_tagged_activities` in activity.py. (#30)

**mcp/tools/protocols.py** — Added `list_tagged_protocols` tool. (#30)

**mcp/tools/directives.py** — Added `list_tagged_directives` tool. (#30)

**README.md** — Split "Batch Operations (12)" into "Batch Operations (9)" and moved reverse tag lookups to their entity sections: Artifacts (8→9), Protocols (8→9), Directives (9→10). (#30)

**#31 (CLAUDE.md)** — Updated `.claude/CLAUDE.md` in place with current v1.2.0 structure (modular tools/ layout, 109 tool count, register_all pattern, entity coverage table). Content persisted to BRAIN via reflected activity tagged claude-md. Not committed to repo per project convention — CLAUDE.md is gitignored and stored in BRAIN.

## How to Verify
1. `grep -r "@mcp.tool()" mcp/tools/ | wc -l` returns 108 (+ 1 health_check in server.py = 109 total)
2. `python -c "import sys; sys.path.insert(0, 'mcp'); from tools import register_all; print('OK')"` — imports clean
3. Verify no `list_tagged_*` tools remain in batch.py
4. Verify `list_tagged_artifacts` is in artifacts.py, `list_tagged_protocols` in protocols.py, `list_tagged_directives` in directives.py

## Deviations
None for #30. For #31, CLAUDE.md is updated locally in `.claude/` and persisted to BRAIN rather than committed to the repo — this follows L's correction that CLAUDE.md stays gitignored and lives in BRAIN.

## Test Results
```
Tool module import: OK
Tool count: 109 (108 in tools/ + 1 health_check in server.py)
```

## Acceptance Checklist
- [x] list_tagged_artifacts moved to artifacts.py (#30)
- [x] list_tagged_protocols moved to protocols.py (#30)
- [x] list_tagged_directives moved to directives.py (#30)
- [x] README Batch Operations updated to (9) (#30)
- [x] README entity sections updated with reverse lookups (#30)
- [x] Tool count unchanged at 109 (#30)
- [x] .claude/CLAUDE.md updated with v1.2.0 structure (#31)

Closes #30, #31