### PR TITLE
[2A-09] Habits MCP tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ brain3-mcp/
         ├── activity.py    ← Activity logging + tagging (9 tools)
         ├── artifacts.py   ← Document storage + tagging (9 tools)
         ├── batch.py       ← Batch create + batch tag (9 tools)
+        ├── habits.py      ← Habit CRUD + completion (6 tools)
         ├── checkins.py    ← Check-in CRUD (5 tools)
         ├── directives.py  ← Behavioral rules + tagging + resolve (10 tools)
         ├── domains.py     ← Life domain CRUD (5 tools)
@@ -107,7 +108,7 @@ Add to your Claude Code settings or project `.mcp.json`:
 }
 ```
 
-## Available Tools (109)
+## Available Tools (115)
 
 ### Health Check (1)
 | Tool | Description |
@@ -175,6 +176,16 @@ Add to your Claude Code settings or project `.mcp.json`:
 | `add_routine_schedule` | Add a schedule entry (day + time) |
 | `list_routine_schedules` | List schedule entries |
 | `delete_routine_schedule` | Remove a schedule entry |
+
+### Habits (6)
+| Tool | Description |
+|------|-------------|
+| `create_habit` | Create a new habit (standalone or under a routine) |
+| `get_habit` | Get habit with parent routine info |
+| `list_habits` | List habits with filters (routine, status, scaffolding) |
+| `update_habit` | Update habit details or scaffolding status |
+| `delete_habit` | Delete a habit |
+| `complete_habit` | Record individual habit completion (idempotent) |
 
 ### Check-ins (5)
 | Tool | Description |

--- a/mcp/tools/__init__.py
+++ b/mcp/tools/__init__.py
@@ -10,6 +10,7 @@ from tools.projects import register as register_projects
 from tools.tasks import register as register_tasks
 from tools.tags import register as register_tags
 from tools.routines import register as register_routines
+from tools.habits import register as register_habits
 from tools.checkins import register as register_checkins
 from tools.activity import register as register_activity
 from tools.reports import register as register_reports
@@ -28,6 +29,7 @@ def register_all(mcp, api) -> None:
     register_tasks(mcp, api)
     register_tags(mcp, api)
     register_routines(mcp, api)
+    register_habits(mcp, api)
     register_checkins(mcp, api)
     register_activity(mcp, api)
     register_reports(mcp, api)

--- a/mcp/tools/activity.py
+++ b/mcp/tools/activity.py
@@ -18,6 +18,7 @@ def register(mcp, api) -> None:
         task_id: str | None = None,
         routine_id: str | None = None,
         checkin_id: str | None = None,
+        habit_id: str | None = None,
         notes: str | None = None,
         energy_before: int | None = None,
         energy_after: int | None = None,
@@ -29,7 +30,7 @@ def register(mcp, api) -> None:
         """Create an activity log entry.
 
         Records what happened and how the user felt. At most one of task_id,
-        routine_id, or checkin_id can be provided to link the entry.
+        routine_id, checkin_id, or habit_id can be provided to link the entry.
 
         Action types: completed, skipped, deferred, started, reflected,
         checked_in.
@@ -42,6 +43,7 @@ def register(mcp, api) -> None:
         validate_uuid(task_id, "task_id")
         validate_uuid(routine_id, "routine_id")
         validate_uuid(checkin_id, "checkin_id")
+        validate_uuid(habit_id, "habit_id")
         validate_range(energy_before, "energy_before")
         validate_range(energy_after, "energy_after")
         validate_range(mood_rating, "mood_rating")
@@ -53,6 +55,7 @@ def register(mcp, api) -> None:
             "task_id": task_id,
             "routine_id": routine_id,
             "checkin_id": checkin_id,
+            "habit_id": habit_id,
             "action_type": action_type,
             "notes": notes,
             "energy_before": energy_before,
@@ -73,13 +76,16 @@ def register(mcp, api) -> None:
         logged_before: str | None = None,
         has_task: bool | None = None,
         has_routine: bool | None = None,
+        has_habit: bool | None = None,
+        has_checkin: bool | None = None,
         tag: str | None = None,
     ) -> list:
         """List activity log entries with optional filters.
 
-        Filter by action type, linked task or routine, date range, or whether
-        entries have a task/routine attached. Results are ordered newest first.
-        Use this to review what the user has been doing and how they felt.
+        Filter by action type, linked task, routine, or habit, date range,
+        or whether entries have a task/routine/habit/checkin attached.
+        Results are ordered newest first. Use this to review what the user
+        has been doing and how they felt.
 
         The tag parameter accepts comma-separated tag names with AND logic.
         Example: tag="session-handoff" or tag="movie,fluxnook" (entries must
@@ -98,6 +104,8 @@ def register(mcp, api) -> None:
                 logged_before=logged_before,
                 has_task=has_task,
                 has_routine=has_routine,
+                has_habit=has_habit,
+                has_checkin=has_checkin,
                 tag=tag,
             ),
         )
@@ -118,6 +126,7 @@ def register(mcp, api) -> None:
         task_id: str | None = None,
         routine_id: str | None = None,
         checkin_id: str | None = None,
+        habit_id: str | None = None,
         action_type: str | None = None,
         notes: str | None = None,
         energy_before: int | None = None,
@@ -134,6 +143,7 @@ def register(mcp, api) -> None:
         validate_uuid(task_id, "task_id")
         validate_uuid(routine_id, "routine_id")
         validate_uuid(checkin_id, "checkin_id")
+        validate_uuid(habit_id, "habit_id")
         validate_enum(action_type, "action_type", ACTION_TYPES)
         validate_range(energy_before, "energy_before")
         validate_range(energy_after, "energy_after")
@@ -143,6 +153,7 @@ def register(mcp, api) -> None:
             "task_id": task_id,
             "routine_id": routine_id,
             "checkin_id": checkin_id,
+            "habit_id": habit_id,
             "action_type": action_type,
             "notes": notes,
             "energy_before": energy_before,

--- a/mcp/tools/habits.py
+++ b/mcp/tools/habits.py
@@ -1,0 +1,187 @@
+"""Habit CRUD and completion tools."""
+
+from validation import (
+    InputValidationError,
+    validate_enum,
+    validate_uuid,
+    validate_required_str,
+    HABIT_STATUSES,
+    HABIT_FREQUENCIES,
+    NOTIFICATION_FREQUENCIES,
+    SCAFFOLDING_STATUSES,
+)
+from tools._helpers import params, strip_nones
+
+
+def register(mcp, api) -> None:
+    """Register habit tools with the MCP server."""
+
+    @mcp.tool()
+    async def create_habit(
+        title: str,
+        routine_id: str | None = None,
+        description: str | None = None,
+        status: str = "active",
+        frequency: str | None = None,
+        notification_frequency: str = "none",
+        scaffolding_status: str = "tracking",
+        introduced_at: str | None = None,
+        graduation_window: int | None = None,
+        graduation_target: float | None = None,
+        graduation_threshold: int | None = None,
+    ) -> dict:
+        """Create a new habit, standalone or under a routine.
+
+        Habits are specific behaviors the user is building. Standalone habits
+        require a frequency (daily, weekdays, weekends, weekly, custom).
+        Routine-linked habits inherit frequency from their parent routine.
+
+        Scaffolding starts at "tracking" — the user just logs completions.
+        Later stages add accountability and graduation criteria.
+        """
+        validate_required_str(title, "title")
+        validate_uuid(routine_id, "routine_id")
+        validate_enum(status, "status", HABIT_STATUSES)
+        validate_enum(frequency, "frequency", HABIT_FREQUENCIES)
+        validate_enum(notification_frequency, "notification_frequency", NOTIFICATION_FREQUENCIES)
+        validate_enum(scaffolding_status, "scaffolding_status", SCAFFOLDING_STATUSES)
+        if routine_id is None and frequency is None:
+            raise InputValidationError(
+                "Missing required parameter: frequency. "
+                "Standalone habits (no routine_id) must specify a frequency."
+            )
+        if graduation_target is not None and not (0.0 <= graduation_target <= 1.0):
+            raise InputValidationError(
+                f"Invalid graduation_target: {graduation_target}. "
+                "Must be between 0.0 and 1.0."
+            )
+        body = strip_nones({
+            "title": title,
+            "routine_id": routine_id,
+            "description": description,
+            "status": status,
+            "frequency": frequency,
+            "notification_frequency": notification_frequency,
+            "scaffolding_status": scaffolding_status,
+            "introduced_at": introduced_at,
+            "graduation_window": graduation_window,
+            "graduation_target": graduation_target,
+            "graduation_threshold": graduation_threshold,
+        })
+        return await api.post("/api/habits/", json=body)
+
+    @mcp.tool()
+    async def get_habit(habit_id: str) -> dict:
+        """Get a habit with its parent routine info.
+
+        Returns habit details including scaffolding status, completion stats,
+        and the parent routine (if linked). Use this to check on a specific
+        habit's progress or configuration.
+        """
+        validate_uuid(habit_id, "habit_id")
+        return await api.get(f"/api/habits/{habit_id}")
+
+    @mcp.tool()
+    async def list_habits(
+        routine_id: str | None = None,
+        status: str | None = None,
+        scaffolding_status: str | None = None,
+    ) -> list:
+        """List habits with optional filters.
+
+        Use this to see what habits the user is building, check on scaffolding
+        progress, or find habits linked to a specific routine. All filters
+        combine with AND logic.
+        """
+        validate_uuid(routine_id, "routine_id")
+        validate_enum(status, "status", HABIT_STATUSES)
+        validate_enum(scaffolding_status, "scaffolding_status", SCAFFOLDING_STATUSES)
+        return await api.get(
+            "/api/habits/",
+            params=params(
+                routine_id=routine_id,
+                status=status,
+                scaffolding_status=scaffolding_status,
+            ),
+        )
+
+    @mcp.tool()
+    async def update_habit(
+        habit_id: str,
+        title: str | None = None,
+        routine_id: str | None = None,
+        description: str | None = None,
+        status: str | None = None,
+        frequency: str | None = None,
+        notification_frequency: str | None = None,
+        scaffolding_status: str | None = None,
+        introduced_at: str | None = None,
+        graduation_window: int | None = None,
+        graduation_target: float | None = None,
+        graduation_threshold: int | None = None,
+    ) -> dict:
+        """Update a habit's details.
+
+        Only provided fields are changed. Use this to advance scaffolding
+        status, pause/resume a habit, adjust graduation criteria, or change
+        notification frequency.
+        """
+        validate_uuid(habit_id, "habit_id")
+        validate_uuid(routine_id, "routine_id")
+        validate_enum(status, "status", HABIT_STATUSES)
+        validate_enum(frequency, "frequency", HABIT_FREQUENCIES)
+        validate_enum(notification_frequency, "notification_frequency", NOTIFICATION_FREQUENCIES)
+        validate_enum(scaffolding_status, "scaffolding_status", SCAFFOLDING_STATUSES)
+        if graduation_target is not None and not (0.0 <= graduation_target <= 1.0):
+            raise InputValidationError(
+                f"Invalid graduation_target: {graduation_target}. "
+                "Must be between 0.0 and 1.0."
+            )
+        body = strip_nones({
+            "title": title,
+            "routine_id": routine_id,
+            "description": description,
+            "status": status,
+            "frequency": frequency,
+            "notification_frequency": notification_frequency,
+            "scaffolding_status": scaffolding_status,
+            "introduced_at": introduced_at,
+            "graduation_window": graduation_window,
+            "graduation_target": graduation_target,
+            "graduation_threshold": graduation_threshold,
+        })
+        return await api.patch(f"/api/habits/{habit_id}", json=body)
+
+    @mcp.tool()
+    async def delete_habit(habit_id: str) -> dict:
+        """Delete a habit permanently.
+
+        Removes the habit and its completion history. Confirm with the user
+        before deleting.
+        """
+        validate_uuid(habit_id, "habit_id")
+        return await api.delete(f"/api/habits/{habit_id}")
+
+    @mcp.tool()
+    async def complete_habit(
+        habit_id: str,
+        completed_date: str | None = None,
+        notes: str | None = None,
+    ) -> dict:
+        """Record an individual habit completion.
+
+        Idempotent — completing the same habit on the same date returns the
+        existing record. Only active habits can be completed. Does NOT
+        auto-complete the parent routine.
+
+        If completed_date is omitted, today's date is used.
+        Date format: YYYY-MM-DD.
+        """
+        validate_uuid(habit_id, "habit_id")
+        body = strip_nones({
+            "completed_date": completed_date,
+            "notes": notes,
+        })
+        return await api.post(
+            f"/api/habits/{habit_id}/complete", json=body or None
+        )

--- a/mcp/validation.py
+++ b/mcp/validation.py
@@ -24,6 +24,12 @@ COGNITIVE_TYPES = {
 }
 ROUTINE_FREQUENCIES = {"daily", "weekdays", "weekends", "weekly", "custom"}
 ROUTINE_STATUSES = {"active", "paused", "retired"}
+HABIT_STATUSES = {"active", "paused", "graduated", "abandoned"}
+HABIT_FREQUENCIES = {"daily", "weekdays", "weekends", "weekly", "custom"}
+NOTIFICATION_FREQUENCIES = {
+    "daily", "every_other_day", "twice_week", "weekly", "graduated", "none",
+}
+SCAFFOLDING_STATUSES = {"tracking", "accountable", "graduated"}
 CHECKIN_TYPES = {"morning", "midday", "evening", "micro", "freeform"}
 ACTION_TYPES = {
     "completed", "skipped", "deferred", "started", "reflected", "checked_in",


### PR DESCRIPTION
## Summary

Adds 6 MCP tools for habits CRUD and completion, exposing the brain3 habits API endpoints as Claude-callable tools. Also updates activity log tools to support the new `habit_id` field from brain3 2A-08. Total tool count: 109 → 115.

## Changes

**New file: `mcp/tools/habits.py`** — 6 tools following the exact pattern from `routines.py`:
- `create_habit` — standalone or routine-linked, with standalone validation (frequency required when no routine_id)
- `get_habit` — returns habit with parent routine info
- `list_habits` — filters: routine_id, status, scaffolding_status
- `update_habit` — partial update of any habit field
- `delete_habit` — permanent deletion with user confirmation guidance
- `complete_habit` — idempotent completion recording, notes idempotency in description

**Modified: `mcp/validation.py`** — Added 4 enum sets:
- `HABIT_STATUSES` (active, paused, graduated, abandoned)
- `HABIT_FREQUENCIES` (daily, weekdays, weekends, weekly, custom)
- `NOTIFICATION_FREQUENCIES` (daily, every_other_day, twice_week, weekly, graduated, none)
- `SCAFFOLDING_STATUSES` (tracking, accountable, graduated)

**Modified: `mcp/tools/__init__.py`** — Registers habits module after routines, before checkins.

**Modified: `mcp/tools/activity.py`** — Three additions:
- `log_activity`: added `habit_id` parameter with UUID validation
- `update_activity`: added `habit_id` parameter with UUID validation
- `list_activity`: added `has_habit` and `has_checkin` boolean filter params

**Modified: `README.md`** — Added Habits section to tool inventory, updated total count to 115, added `habits.py` to project structure tree.

## How to Verify

1. Start the MCP server: `cd brain3-mcp/mcp && python server.py`
2. Or use MCP Inspector: `mcp dev server.py`
3. Confirm 115 tools are registered (was 109)
4. Verify habit tools appear: `create_habit`, `get_habit`, `list_habits`, `update_habit`, `delete_habit`, `complete_habit`
5. Test `create_habit` standalone validation — omitting both `routine_id` and `frequency` should return an InputValidationError
6. Test `create_habit` with `graduation_target` outside 0.0–1.0 should return an InputValidationError
7. Verify `log_activity` and `update_activity` accept `habit_id` parameter
8. Verify `list_activity` accepts `has_habit` and `has_checkin` parameters

## Deviations

- Added `graduation_target` range validation (0.0–1.0) in both `create_habit` and `update_habit`. Not explicitly in the spec but consistent with the field's semantics and existing validation patterns.
- `HABIT_FREQUENCIES` added as a separate enum set even though values match `ROUTINE_FREQUENCIES`. Spec listed it explicitly and having a distinct name makes the intent clear at usage sites.

## Test Results

```
$ python -c "from server import mcp; import asyncio; tools = asyncio.run(mcp.list_tools()); print(len(tools))"
115

$ python -c "from server import mcp; import asyncio; tools = asyncio.run(mcp.list_tools()); print([t.name for t in tools if 'habit' in t.name])"
['create_habit', 'get_habit', 'list_habits', 'update_habit', 'delete_habit', 'complete_habit']
```

All 6 habit tools registered. Server starts cleanly. Import chain verified.

## Acceptance Checklist

- [x] All 6 tools registered and callable
- [x] `list_habits` supports `routine_id`, `status`, `scaffolding_status` filters
- [x] `complete_habit` wraps POST /api/habits/{id}/complete
- [x] `complete_habit` description notes idempotency behavior
- [x] Input validation on all parameters (UUID, enum, required string, range)
- [x] Tool descriptions follow existing docstring conventions (explain when/why)
- [x] `HABIT_STATUSES`, `HABIT_FREQUENCIES`, `NOTIFICATION_FREQUENCIES`, `SCAFFOLDING_STATUSES` added to validation.py
- [x] `create_habit` validates `frequency` is provided when `routine_id` is None
- [x] `_strip_nones()` used for create/update payloads
- [x] `_params()` used for list query parameters
- [x] `log_activity` and `update_activity` updated with `habit_id` parameter
- [x] `list_activity` updated with `has_habit` and `has_checkin` filter params
- [x] README tool count updated (115)
- [x] Habit Tools section placed after Routine Tools, before Check-in Tools

Closes #26