### PR TITLE
2A-07: Fix complete_routine missing status/freeform_note params

### DIFF
--- a/mcp/tools/routines.py
+++ b/mcp/tools/routines.py
@@ -5,6 +5,7 @@ from validation import (
     validate_range,
     validate_required_str,
     validate_uuid,
+    COMPLETION_STATUSES,
     DAYS_OF_WEEK,
     ROUTINE_FREQUENCIES,
     ROUTINE_STATUSES,
@@ -133,16 +134,31 @@ def register(mcp, api) -> None:
     async def complete_routine(
         routine_id: str,
         completed_date: str | None = None,
+        status: str = "all_done",
+        freeform_note: str | None = None,
     ) -> dict:
         """Record a routine completion and evaluate the streak.
 
         Call this when the user completes a routine. Returns updated streak
         info including whether the streak was broken and recovered.
+
+        Three completion modes:
+        - all_done (default): routine fully completed.
+        - partial: routine partially completed — use freeform_note to
+          explain what was done.
+        - skipped: routine intentionally skipped — use freeform_note to
+          capture why.
+
         If completed_date is omitted, today's date is used.
         Date format: YYYY-MM-DD.
         """
         validate_uuid(routine_id, "routine_id")
-        body = strip_nones({"completed_date": completed_date})
+        validate_enum(status, "status", COMPLETION_STATUSES)
+        body = strip_nones({
+            "completed_date": completed_date,
+            "status": status,
+            "freeform_note": freeform_note,
+        })
         return await api.post(
             f"/api/routines/{routine_id}/complete", json=body or None
         )

--- a/mcp/validation.py
+++ b/mcp/validation.py
@@ -30,6 +30,7 @@ NOTIFICATION_FREQUENCIES = {
     "daily", "every_other_day", "twice_week", "weekly", "graduated", "none",
 }
 SCAFFOLDING_STATUSES = {"tracking", "accountable", "graduated"}
+COMPLETION_STATUSES = {"all_done", "partial", "skipped"}
 CHECKIN_TYPES = {"morning", "midday", "evening", "micro", "freeform"}
 ACTION_TYPES = {
     "completed", "skipped", "deferred", "started", "reflected", "checked_in",


### PR DESCRIPTION
Closes #42

## Summary
The `complete_routine` MCP tool was missing the `status` and `freeform_note` parameters added to the BRAIN 3.0 API in brain3#131. All completions defaulted to `all_done` with no note — partial and skipped completions could not be triggered through MCP.

## Changes
- **`mcp/validation.py`** — Added `COMPLETION_STATUSES` enum set (`all_done`, `partial`, `skipped`)
- **`mcp/tools/routines.py`** — Added `status` (default `all_done`) and `freeform_note` (optional) parameters to `complete_routine`. Added enum validation for `status`. Updated tool description to explain the three completion modes. Both parameters forwarded to the API via `strip_nones`.

## How to Verify
1. Start the MCP server
2. Call `complete_routine` with `routine_id` only → should succeed (defaults to `all_done`)
3. Call with `status="partial"` and `freeform_note="only did half"` → both forwarded to API
4. Call with `status="skipped"` and `freeform_note="felt sick"` → both forwarded to API
5. Call with `status="invalid"` → should return validation error listing allowed values
6. Verify tool count remains 115 (no new tools added)

## Deviations
None — fix matches the BRAIN task spec exactly.

**Finding (pre-existing):** README.md states 109 tools but actual count is 115. This predates this PR (likely from the habits.py addition in #41). Filed separately.

## Test Results
```
$ python -c "import server; print('OK')"
Server module loaded successfully

$ python -c "... list_tools() ..."
Tool count: 115
complete_routine params: ['routine_id', 'completed_date', 'status', 'freeform_note']
```

## Acceptance Checklist
- [x] `complete_routine` tool accepts `status` parameter
- [x] `complete_routine` tool accepts `freeform_note` parameter
- [x] Both parameters forwarded to API
- [x] Tool description updated with three completion modes
- [x] MCP server starts cleanly
- [x] No new tools added — tool count unchanged