### PR TITLE
2B-06: Notification queue & response recording MCP tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # BRAIN 3.0 MCP Server
 
-MCP (Model Context Protocol) server that gives Claude full access to the BRAIN 3.0 API. Every API endpoint is exposed as a tool Claude can call — 109 tools covering the seven pillars, knowledge layer, batch operations, and reporting. Turns your task/routine/goal/knowledge database into a conversational partner.
+MCP (Model Context Protocol) server that gives Claude full access to the BRAIN 3.0 API. Every API endpoint is exposed as a tool Claude can call — 121 tools covering the seven pillars, knowledge layer, notification queue, batch operations, and reporting. Turns your task/routine/goal/knowledge database into a conversational partner.
 
 ## Project Structure
 
@@ -22,6 +22,7 @@ brain3-mcp/
         ├── artifacts.py   ← Document storage + tagging (9 tools)
         ├── batch.py       ← Batch create + batch tag (9 tools)
         ├── habits.py      ← Habit CRUD + completion (6 tools)
+        ├── notifications.py ← Notification queue + response (6 tools)
         ├── checkins.py    ← Check-in CRUD (5 tools)
         ├── directives.py  ← Behavioral rules + tagging + resolve (10 tools)
         ├── domains.py     ← Life domain CRUD (5 tools)
@@ -108,7 +109,7 @@ Add to your Claude Code settings or project `.mcp.json`:
 }
 ```
 
-## Available Tools (115)
+## Available Tools (121)
 
 ### Health Check (1)
 | Tool | Description |
@@ -186,6 +187,16 @@ Add to your Claude Code settings or project `.mcp.json`:
 | `update_habit` | Update habit details or scaffolding status |
 | `delete_habit` | Delete a habit |
 | `complete_habit` | Record individual habit completion (idempotent) |
+
+### Notifications (6)
+| Tool | Description |
+|------|-------------|
+| `create_notification` | Schedule a notification for delivery |
+| `get_notification` | Retrieve a notification by ID |
+| `list_notifications` | Browse notifications with composable filters |
+| `update_notification` | Modify a pending or delivered notification |
+| `delete_notification` | Remove a notification from the queue |
+| `respond_to_notification` | Record a user response to a delivered notification |
 
 ### Check-ins (5)
 | Tool | Description |

--- a/mcp/tests/conftest.py
+++ b/mcp/tests/conftest.py
@@ -1,0 +1,26 @@
+"""Shared fixtures for MCP tool tests."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from client import BrainAPIClient, BrainAPIError
+from mcp.server.fastmcp import FastMCP
+
+
+@pytest.fixture()
+def api():
+    """Mock BrainAPIClient with async methods."""
+    mock = AsyncMock(spec=BrainAPIClient)
+    return mock
+
+
+@pytest.fixture()
+def mcp_server():
+    """Fresh FastMCP instance for registering tools."""
+    return FastMCP("BRAIN 3.0 Test")
+
+
+def make_api_error(status_code: int, detail: str) -> BrainAPIError:
+    """Create a BrainAPIError mimicking an HTTP error response."""
+    return BrainAPIError(f"API error ({status_code}): {detail}")

--- a/mcp/tests/test_notifications.py
+++ b/mcp/tests/test_notifications.py
@@ -1,0 +1,389 @@
+"""Tests for notification queue MCP tools."""
+
+import pytest
+from unittest.mock import AsyncMock
+
+from client import BrainAPIError
+from mcp.server.fastmcp import FastMCP
+from tools.notifications import register
+from validation import InputValidationError
+from tests.conftest import make_api_error
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+VALID_UUID = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+VALID_UUID_2 = "b2c3d4e5-f6a7-8901-bcde-f12345678901"
+
+
+@pytest.fixture()
+def api():
+    return AsyncMock()
+
+
+@pytest.fixture()
+def tools(api):
+    """Register notification tools and return a dict of tool functions."""
+    mcp = FastMCP("test")
+    register(mcp, api)
+    # Access registered tool functions directly from the internal manager
+    return {
+        name: tool.fn
+        for name, tool in mcp._tool_manager._tools.items()
+    }
+
+
+# ---------------------------------------------------------------------------
+# create_notification
+# ---------------------------------------------------------------------------
+
+class TestCreateNotification:
+
+    @pytest.mark.anyio
+    async def test_happy_path(self, tools, api):
+        api.post.return_value = {"id": VALID_UUID, "status": "pending"}
+        result = await tools["create_notification"](
+            notification_type="habit_nudge",
+            scheduled_at="2026-04-14T09:00:00Z",
+            target_entity_type="habit",
+            target_entity_id=VALID_UUID,
+            message="Time to check in on your morning routine!",
+            scheduled_by="claude",
+        )
+        assert result["id"] == VALID_UUID
+        api.post.assert_called_once()
+        call_args = api.post.call_args
+        assert call_args[0][0] == "/api/notifications/"
+        body = call_args[1]["json"]
+        assert body["notification_type"] == "habit_nudge"
+        assert body["scheduled_by"] == "claude"
+        assert body["delivery_type"] == "notification"
+
+    @pytest.mark.anyio
+    async def test_all_optional_params(self, tools, api):
+        api.post.return_value = {"id": VALID_UUID}
+        await tools["create_notification"](
+            notification_type="routine_checklist",
+            scheduled_at="2026-04-14T09:00:00Z",
+            target_entity_type="routine",
+            target_entity_id=VALID_UUID,
+            message="Checklist time",
+            scheduled_by="rule",
+            delivery_type="notification",
+            canned_responses=["done", "skip", "snooze"],
+            expires_at="2026-04-14T10:00:00Z",
+            rule_id=VALID_UUID_2,
+        )
+        body = api.post.call_args[1]["json"]
+        assert body["canned_responses"] == ["done", "skip", "snooze"]
+        assert body["expires_at"] == "2026-04-14T10:00:00Z"
+        assert body["rule_id"] == VALID_UUID_2
+
+    @pytest.mark.anyio
+    async def test_invalid_notification_type(self, tools):
+        with pytest.raises(InputValidationError, match="notification_type"):
+            await tools["create_notification"](
+                notification_type="invalid_type",
+                scheduled_at="2026-04-14T09:00:00Z",
+                target_entity_type="habit",
+                target_entity_id=VALID_UUID,
+                message="test",
+                scheduled_by="claude",
+            )
+
+    @pytest.mark.anyio
+    async def test_invalid_scheduled_by(self, tools):
+        with pytest.raises(InputValidationError, match="scheduled_by"):
+            await tools["create_notification"](
+                notification_type="habit_nudge",
+                scheduled_at="2026-04-14T09:00:00Z",
+                target_entity_type="habit",
+                target_entity_id=VALID_UUID,
+                message="test",
+                scheduled_by="user",
+            )
+
+    @pytest.mark.anyio
+    async def test_invalid_target_entity_type(self, tools):
+        with pytest.raises(InputValidationError, match="target_entity_type"):
+            await tools["create_notification"](
+                notification_type="habit_nudge",
+                scheduled_at="2026-04-14T09:00:00Z",
+                target_entity_type="widget",
+                target_entity_id=VALID_UUID,
+                message="test",
+                scheduled_by="claude",
+            )
+
+    @pytest.mark.anyio
+    async def test_invalid_uuid(self, tools):
+        with pytest.raises(InputValidationError, match="target_entity_id"):
+            await tools["create_notification"](
+                notification_type="habit_nudge",
+                scheduled_at="2026-04-14T09:00:00Z",
+                target_entity_type="habit",
+                target_entity_id="not-a-uuid",
+                message="test",
+                scheduled_by="claude",
+            )
+
+    @pytest.mark.anyio
+    async def test_missing_required_message(self, tools):
+        with pytest.raises(InputValidationError, match="message"):
+            await tools["create_notification"](
+                notification_type="habit_nudge",
+                scheduled_at="2026-04-14T09:00:00Z",
+                target_entity_type="habit",
+                target_entity_id=VALID_UUID,
+                message="",
+                scheduled_by="claude",
+            )
+
+    @pytest.mark.anyio
+    async def test_message_too_long(self, tools):
+        with pytest.raises(InputValidationError, match="2000"):
+            await tools["create_notification"](
+                notification_type="habit_nudge",
+                scheduled_at="2026-04-14T09:00:00Z",
+                target_entity_type="habit",
+                target_entity_id=VALID_UUID,
+                message="x" * 2001,
+                scheduled_by="claude",
+            )
+
+
+# ---------------------------------------------------------------------------
+# get_notification
+# ---------------------------------------------------------------------------
+
+class TestGetNotification:
+
+    @pytest.mark.anyio
+    async def test_happy_path(self, tools, api):
+        api.get.return_value = {"id": VALID_UUID, "status": "pending"}
+        result = await tools["get_notification"](notification_id=VALID_UUID)
+        assert result["id"] == VALID_UUID
+        api.get.assert_called_once_with(f"/api/notifications/{VALID_UUID}")
+
+    @pytest.mark.anyio
+    async def test_invalid_uuid(self, tools):
+        with pytest.raises(InputValidationError, match="notification_id"):
+            await tools["get_notification"](notification_id="bad")
+
+    @pytest.mark.anyio
+    async def test_not_found(self, tools, api):
+        api.get.side_effect = make_api_error(404, "Notification not found")
+        with pytest.raises(BrainAPIError, match="404"):
+            await tools["get_notification"](notification_id=VALID_UUID)
+
+
+# ---------------------------------------------------------------------------
+# list_notifications
+# ---------------------------------------------------------------------------
+
+class TestListNotifications:
+
+    @pytest.mark.anyio
+    async def test_no_filters(self, tools, api):
+        api.get.return_value = []
+        result = await tools["list_notifications"]()
+        assert result == []
+        api.get.assert_called_once_with("/api/notifications/", params=None)
+
+    @pytest.mark.anyio
+    async def test_all_filters(self, tools, api):
+        api.get.return_value = [{"id": VALID_UUID}]
+        await tools["list_notifications"](
+            notification_type="habit_nudge",
+            status="pending",
+            delivery_type="notification",
+            target_entity_type="habit",
+            target_entity_id=VALID_UUID,
+            scheduled_by="claude",
+            scheduled_after="2026-04-01T00:00:00Z",
+            scheduled_before="2026-04-30T00:00:00Z",
+            has_response=False,
+            rule_id=VALID_UUID_2,
+        )
+        call_params = api.get.call_args[1]["params"]
+        assert call_params["notification_type"] == "habit_nudge"
+        assert call_params["status"] == "pending"
+        assert call_params["has_response"] is False
+        assert call_params["rule_id"] == VALID_UUID_2
+
+    @pytest.mark.anyio
+    async def test_invalid_status_filter(self, tools):
+        with pytest.raises(InputValidationError, match="status"):
+            await tools["list_notifications"](status="invalid")
+
+    @pytest.mark.anyio
+    async def test_invalid_notification_type_filter(self, tools):
+        with pytest.raises(InputValidationError, match="notification_type"):
+            await tools["list_notifications"](notification_type="bogus")
+
+
+# ---------------------------------------------------------------------------
+# update_notification
+# ---------------------------------------------------------------------------
+
+class TestUpdateNotification:
+
+    @pytest.mark.anyio
+    async def test_happy_path(self, tools, api):
+        api.patch.return_value = {"id": VALID_UUID, "message": "Updated"}
+        result = await tools["update_notification"](
+            notification_id=VALID_UUID,
+            message="Updated",
+        )
+        assert result["message"] == "Updated"
+        call_args = api.patch.call_args
+        assert call_args[0][0] == f"/api/notifications/{VALID_UUID}"
+        assert call_args[1]["json"]["message"] == "Updated"
+
+    @pytest.mark.anyio
+    async def test_status_transition(self, tools, api):
+        api.patch.return_value = {"id": VALID_UUID, "status": "delivered"}
+        await tools["update_notification"](
+            notification_id=VALID_UUID,
+            status="delivered",
+        )
+        body = api.patch.call_args[1]["json"]
+        assert body["status"] == "delivered"
+
+    @pytest.mark.anyio
+    async def test_invalid_uuid(self, tools):
+        with pytest.raises(InputValidationError, match="notification_id"):
+            await tools["update_notification"](notification_id="bad")
+
+    @pytest.mark.anyio
+    async def test_invalid_status(self, tools):
+        with pytest.raises(InputValidationError, match="status"):
+            await tools["update_notification"](
+                notification_id=VALID_UUID, status="invalid"
+            )
+
+    @pytest.mark.anyio
+    async def test_message_too_long(self, tools):
+        with pytest.raises(InputValidationError, match="2000"):
+            await tools["update_notification"](
+                notification_id=VALID_UUID, message="x" * 2001
+            )
+
+    @pytest.mark.anyio
+    async def test_not_found(self, tools, api):
+        api.patch.side_effect = make_api_error(404, "Notification not found")
+        with pytest.raises(BrainAPIError, match="404"):
+            await tools["update_notification"](
+                notification_id=VALID_UUID, message="test"
+            )
+
+
+# ---------------------------------------------------------------------------
+# delete_notification
+# ---------------------------------------------------------------------------
+
+class TestDeleteNotification:
+
+    @pytest.mark.anyio
+    async def test_happy_path(self, tools, api):
+        api.delete.return_value = {"deleted": True}
+        result = await tools["delete_notification"](notification_id=VALID_UUID)
+        assert result["deleted"] is True
+        api.delete.assert_called_once_with(f"/api/notifications/{VALID_UUID}")
+
+    @pytest.mark.anyio
+    async def test_invalid_uuid(self, tools):
+        with pytest.raises(InputValidationError, match="notification_id"):
+            await tools["delete_notification"](notification_id="bad")
+
+    @pytest.mark.anyio
+    async def test_not_found(self, tools, api):
+        api.delete.side_effect = make_api_error(404, "Notification not found")
+        with pytest.raises(BrainAPIError, match="404"):
+            await tools["delete_notification"](notification_id=VALID_UUID)
+
+
+# ---------------------------------------------------------------------------
+# respond_to_notification
+# ---------------------------------------------------------------------------
+
+class TestRespondToNotification:
+
+    @pytest.mark.anyio
+    async def test_happy_path(self, tools, api):
+        api.post.return_value = {
+            "id": VALID_UUID, "status": "responded", "response": "done",
+        }
+        result = await tools["respond_to_notification"](
+            notification_id=VALID_UUID,
+            response="done",
+        )
+        assert result["status"] == "responded"
+        call_args = api.post.call_args
+        assert call_args[0][0] == f"/api/notifications/{VALID_UUID}/respond"
+        assert call_args[1]["json"]["response"] == "done"
+
+    @pytest.mark.anyio
+    async def test_with_response_note(self, tools, api):
+        api.post.return_value = {"id": VALID_UUID, "status": "responded"}
+        await tools["respond_to_notification"](
+            notification_id=VALID_UUID,
+            response="partial",
+            response_note="Did two out of three items",
+        )
+        body = api.post.call_args[1]["json"]
+        assert body["response_note"] == "Did two out of three items"
+
+    @pytest.mark.anyio
+    async def test_invalid_uuid(self, tools):
+        with pytest.raises(InputValidationError, match="notification_id"):
+            await tools["respond_to_notification"](
+                notification_id="bad", response="done"
+            )
+
+    @pytest.mark.anyio
+    async def test_missing_response(self, tools):
+        with pytest.raises(InputValidationError, match="response"):
+            await tools["respond_to_notification"](
+                notification_id=VALID_UUID, response=""
+            )
+
+    @pytest.mark.anyio
+    async def test_409_pending(self, tools, api):
+        api.post.side_effect = make_api_error(
+            409, "Notification has not been delivered yet"
+        )
+        with pytest.raises(BrainAPIError, match="409"):
+            await tools["respond_to_notification"](
+                notification_id=VALID_UUID, response="done"
+            )
+
+    @pytest.mark.anyio
+    async def test_409_already_responded(self, tools, api):
+        api.post.side_effect = make_api_error(
+            409, "Notification has already been responded to"
+        )
+        with pytest.raises(BrainAPIError, match="409"):
+            await tools["respond_to_notification"](
+                notification_id=VALID_UUID, response="done"
+            )
+
+    @pytest.mark.anyio
+    async def test_410_expired(self, tools, api):
+        api.post.side_effect = make_api_error(
+            410, "Notification has expired"
+        )
+        with pytest.raises(BrainAPIError, match="410"):
+            await tools["respond_to_notification"](
+                notification_id=VALID_UUID, response="done"
+            )
+
+    @pytest.mark.anyio
+    async def test_not_found(self, tools, api):
+        api.post.side_effect = make_api_error(404, "Notification not found")
+        with pytest.raises(BrainAPIError, match="404"):
+            await tools["respond_to_notification"](
+                notification_id=VALID_UUID, response="done"
+            )

--- a/mcp/tools/__init__.py
+++ b/mcp/tools/__init__.py
@@ -18,6 +18,7 @@ from tools.artifacts import register as register_artifacts
 from tools.protocols import register as register_protocols
 from tools.directives import register as register_directives
 from tools.skills import register as register_skills
+from tools.notifications import register as register_notifications
 from tools.batch import register as register_batch
 
 
@@ -37,4 +38,5 @@ def register_all(mcp, api) -> None:
     register_protocols(mcp, api)
     register_directives(mcp, api)
     register_skills(mcp, api)
+    register_notifications(mcp, api)
     register_batch(mcp, api)

--- a/mcp/tools/notifications.py
+++ b/mcp/tools/notifications.py
@@ -1,0 +1,218 @@
+"""Notification queue CRUD and response recording tools."""
+
+from validation import (
+    InputValidationError,
+    validate_enum,
+    validate_uuid,
+    validate_required_str,
+    NOTIFICATION_TYPES,
+    NOTIFICATION_STATUSES,
+    DELIVERY_TYPES,
+    SCHEDULED_BY_VALUES,
+    TARGET_ENTITY_TYPES,
+)
+from tools._helpers import params, strip_nones
+
+
+def register(mcp, api) -> None:
+    """Register notification queue tools with the MCP server."""
+
+    @mcp.tool()
+    async def create_notification(
+        notification_type: str,
+        scheduled_at: str,
+        target_entity_type: str,
+        target_entity_id: str,
+        message: str,
+        scheduled_by: str,
+        delivery_type: str = "notification",
+        canned_responses: list[str] | None = None,
+        expires_at: str | None = None,
+        rule_id: str | None = None,
+    ) -> dict:
+        """Schedule a notification for delivery to the user.
+
+        This is how you write to the notification queue during sessions.
+        Use this to nudge the user about habits, remind them of routines,
+        prompt check-ins, flag upcoming deadlines, or share pattern
+        observations.
+
+        notification_type controls default canned_responses and expiry
+        windows — omit canned_responses to use the type's defaults.
+
+        scheduled_by should be "claude" when you create notifications
+        directly, "system" for automated processes, or "rule" when
+        triggered by a notification rule (pair with rule_id).
+
+        Types: habit_nudge, routine_checklist, checkin_prompt,
+        time_block_reminder, deadline_event_alert, pattern_observation,
+        stale_work_nudge.
+        """
+        validate_required_str(notification_type, "notification_type")
+        validate_required_str(scheduled_at, "scheduled_at")
+        validate_required_str(target_entity_type, "target_entity_type")
+        validate_required_str(target_entity_id, "target_entity_id")
+        validate_required_str(message, "message")
+        validate_required_str(scheduled_by, "scheduled_by")
+        validate_enum(notification_type, "notification_type", NOTIFICATION_TYPES)
+        validate_enum(delivery_type, "delivery_type", DELIVERY_TYPES)
+        validate_enum(scheduled_by, "scheduled_by", SCHEDULED_BY_VALUES)
+        validate_enum(target_entity_type, "target_entity_type", TARGET_ENTITY_TYPES)
+        validate_uuid(target_entity_id, "target_entity_id")
+        validate_uuid(rule_id, "rule_id")
+        if len(message) > 2000:
+            raise InputValidationError(
+                "Invalid message: exceeds 2000 character limit."
+            )
+        body = strip_nones({
+            "notification_type": notification_type,
+            "scheduled_at": scheduled_at,
+            "target_entity_type": target_entity_type,
+            "target_entity_id": target_entity_id,
+            "message": message,
+            "scheduled_by": scheduled_by,
+            "delivery_type": delivery_type,
+            "canned_responses": canned_responses,
+            "expires_at": expires_at,
+            "rule_id": rule_id,
+        })
+        return await api.post("/api/notifications/", json=body)
+
+    @mcp.tool()
+    async def get_notification(notification_id: str) -> dict:
+        """Retrieve a specific notification by ID.
+
+        Returns the full notification including status, message,
+        canned_responses, response (if any), and timestamps. Use this
+        to check whether a notification has been delivered or responded to.
+        """
+        validate_uuid(notification_id, "notification_id")
+        return await api.get(f"/api/notifications/{notification_id}")
+
+    @mcp.tool()
+    async def list_notifications(
+        notification_type: str | None = None,
+        status: str | None = None,
+        delivery_type: str | None = None,
+        target_entity_type: str | None = None,
+        target_entity_id: str | None = None,
+        scheduled_by: str | None = None,
+        scheduled_after: str | None = None,
+        scheduled_before: str | None = None,
+        has_response: bool | None = None,
+        rule_id: str | None = None,
+    ) -> list:
+        """Browse notifications with composable filters.
+
+        All filter parameters are optional and combine with AND logic.
+        Results are ordered by scheduled_at descending (newest first).
+
+        Common patterns:
+        - Pending queue: status="pending"
+        - Delivered but unanswered: status="delivered"
+        - Silence tracking: has_response=false with a scheduled_after window
+        - By origin: scheduled_by="claude" or scheduled_by="rule"
+        - By target: target_entity_type + target_entity_id
+        """
+        validate_enum(notification_type, "notification_type", NOTIFICATION_TYPES)
+        validate_enum(status, "status", NOTIFICATION_STATUSES)
+        validate_enum(delivery_type, "delivery_type", DELIVERY_TYPES)
+        validate_enum(target_entity_type, "target_entity_type", TARGET_ENTITY_TYPES)
+        validate_uuid(target_entity_id, "target_entity_id")
+        validate_enum(scheduled_by, "scheduled_by", SCHEDULED_BY_VALUES)
+        validate_uuid(rule_id, "rule_id")
+        return await api.get(
+            "/api/notifications/",
+            params=params(
+                notification_type=notification_type,
+                status=status,
+                delivery_type=delivery_type,
+                target_entity_type=target_entity_type,
+                target_entity_id=target_entity_id,
+                scheduled_by=scheduled_by,
+                scheduled_after=scheduled_after,
+                scheduled_before=scheduled_before,
+                has_response=has_response,
+                rule_id=rule_id,
+            ),
+        )
+
+    @mcp.tool()
+    async def update_notification(
+        notification_id: str,
+        scheduled_at: str | None = None,
+        message: str | None = None,
+        canned_responses: list[str] | None = None,
+        expires_at: str | None = None,
+        status: str | None = None,
+    ) -> dict:
+        """Modify a notification's mutable fields.
+
+        Only provided fields are changed. Status transitions follow a
+        state machine: pending -> delivered -> responded, and
+        pending/delivered -> expired. The API rejects invalid transitions.
+
+        Immutable fields (notification_type, target_entity_type,
+        target_entity_id, scheduled_by, response, responded_at) cannot
+        be changed — delete and recreate instead.
+
+        Use this to reschedule a pending notification, update its message,
+        or transition its status (e.g., mark as delivered).
+        """
+        validate_uuid(notification_id, "notification_id")
+        validate_enum(status, "status", NOTIFICATION_STATUSES)
+        if message is not None and len(message) > 2000:
+            raise InputValidationError(
+                "Invalid message: exceeds 2000 character limit."
+            )
+        body = strip_nones({
+            "scheduled_at": scheduled_at,
+            "message": message,
+            "canned_responses": canned_responses,
+            "expires_at": expires_at,
+            "status": status,
+        })
+        return await api.patch(
+            f"/api/notifications/{notification_id}", json=body
+        )
+
+    @mcp.tool()
+    async def delete_notification(notification_id: str) -> dict:
+        """Remove a notification from the queue permanently.
+
+        Use this to cancel a pending notification that is no longer
+        relevant, or to clean up expired/responded notifications.
+        Confirm with the user before deleting.
+        """
+        validate_uuid(notification_id, "notification_id")
+        return await api.delete(f"/api/notifications/{notification_id}")
+
+    @mcp.tool()
+    async def respond_to_notification(
+        notification_id: str,
+        response: str,
+        response_note: str | None = None,
+    ) -> dict:
+        """Record a user response to a delivered notification.
+
+        The notification must be in "delivered" status. Responding to a
+        pending notification returns 409, responding to an already-responded
+        notification returns 409, and responding to an expired notification
+        returns 410.
+
+        The response must match one of the notification's canned_responses
+        or be "partial". Use response_note for freeform context from the
+        user (up to 1000 chars).
+
+        This closes the feedback loop — the response data feeds into
+        pattern analysis and future notification tuning.
+        """
+        validate_uuid(notification_id, "notification_id")
+        validate_required_str(response, "response")
+        body = strip_nones({
+            "response": response,
+            "response_note": response_note,
+        })
+        return await api.post(
+            f"/api/notifications/{notification_id}/respond", json=body
+        )

--- a/mcp/validation.py
+++ b/mcp/validation.py
@@ -42,6 +42,15 @@ ARTIFACT_TYPES = {
     "document", "protocol", "brief", "prompt", "template", "journal", "spec",
 }
 DIRECTIVE_SCOPES = {"global", "skill", "agent"}
+NOTIFICATION_TYPES = {
+    "habit_nudge", "routine_checklist", "checkin_prompt",
+    "time_block_reminder", "deadline_event_alert", "pattern_observation",
+    "stale_work_nudge",
+}
+NOTIFICATION_STATUSES = {"pending", "delivered", "responded", "expired"}
+DELIVERY_TYPES = {"notification"}
+SCHEDULED_BY_VALUES = {"system", "claude", "rule"}
+TARGET_ENTITY_TYPES = {"habit", "routine", "task", "checkin", "goal", "project"}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Implements 6 MCP tools that wrap the notification queue API endpoints from brain3 [2B-02] and [2B-03]. These tools give Claude full read/write access to the notification system during sessions — scheduling notifications, querying the queue, recording user responses, and managing notification lifecycle.

Closes #44 · Implements WilliM233/brain3#124

## Changes

- **`mcp/validation.py`** — Added `NOTIFICATION_TYPES`, `NOTIFICATION_STATUSES`, `DELIVERY_TYPES`, `SCHEDULED_BY_VALUES`, and `TARGET_ENTITY_TYPES` enum constants for pre-request validation.
- **`mcp/tools/notifications.py`** — New module with 6 tools:
  - `create_notification` — POST `/api/notifications/` (schedule a notification)
  - `get_notification` — GET `/api/notifications/{id}` (retrieve by ID)
  - `list_notifications` — GET `/api/notifications/` with 10 composable filters
  - `update_notification` — PATCH `/api/notifications/{id}` (partial update)
  - `delete_notification` — DELETE `/api/notifications/{id}`
  - `respond_to_notification` — POST `/api/notifications/{id}/respond` (record response)
- **`mcp/tools/__init__.py`** — Registered the notifications module in `register_all`.
- **`mcp/tests/`** — New test infrastructure (`conftest.py` with mock API client pattern) and `test_notifications.py` with 32 tests.
- **`README.md`** — Updated tool count (115 → 121), added Notifications section to tool inventory and project structure.

## How to Verify

1. Checkout the branch: `git checkout feature/2B-06-notification-mcp-tools`
2. Install deps: `cd mcp && pip install -r requirements.txt`
3. Run tests: `python -m pytest tests/test_notifications.py -v` (32 tests, all pass)
4. Verify server starts: `python -c "from mcp.server.fastmcp import FastMCP; from client import BrainAPIClient; from tools import register_all; m = FastMCP('t'); register_all(m, BrainAPIClient()); import asyncio; print(len(asyncio.run(m.list_tools())))"`  → should print 120 (+ 1 health_check = 121 total)
5. With brain3 API running, test tools via MCP Inspector: `mcp dev server.py`

## Deviations

None. All 6 tools map 1:1 to the API endpoints specified in the issue.

## Test Results

```
32 passed in 0.22s
```

Tests cover:
- Happy path for each tool (6)
- Validation failures — invalid enum, missing required, bad UUID, message length (8)
- 404 handling for get/update/delete/respond (4)
- respond_to_notification error cases — 409 pending, 409 already responded, 410 expired (3)
- Filter combinations, optional params, response notes (11)

## Acceptance Checklist

- [x] All 6 MCP tools registered in server.py
- [x] All 6 client.py methods implemented (tools call api directly)
- [x] Validation constants added to validation.py
- [x] Tool descriptions written for Claude (guidance, not just parameter lists)
- [x] create_notification: all parameters accepted, notification created via API
- [x] get_notification: returns full notification by ID
- [x] list_notifications: all 10 filter parameters functional
- [x] update_notification: partial update with status transition validation
- [x] delete_notification: removes notification
- [x] respond_to_notification: records response via sub-resource endpoint
- [x] Tests: each tool happy path
- [x] Tests: validation failures (invalid enum, missing required params)
- [x] Tests: 404 handling for get/update/delete/respond
- [x] Tests: respond_to_notification error cases (409 pending, 409 responded, 410 expired)