### PR TITLE
2E-01: Streamable HTTP transport entry point

### DIFF
--- a/mcp/server.py
+++ b/mcp/server.py
@@ -1,15 +1,24 @@
 """BRAIN 3.0 MCP Server.
 
 Exposes every BRAIN 3.0 API endpoint as an MCP tool that Claude can call.
-Runs via stdio transport as a subprocess of the Claude client.
+Supports two transport modes:
+- stdio (default): runs as a subprocess of the Claude client
+- streamable HTTP: runs as a network-accessible server
 """
+
+import os
+import sys
 
 from mcp.server.fastmcp import FastMCP
 
 from client import BrainAPIClient
 from tools import register_all
 
-mcp = FastMCP("BRAIN 3.0")
+transport = os.environ.get("MCP_TRANSPORT", "stdio")
+host = os.environ.get("MCP_HOST", "0.0.0.0")
+port = int(os.environ.get("MCP_PORT", "8001"))
+
+mcp = FastMCP("BRAIN 3.0", host=host, port=port)
 api = BrainAPIClient()
 
 register_all(mcp, api)
@@ -34,4 +43,12 @@ async def health_check() -> dict:
 # ---------------------------------------------------------------------------
 
 if __name__ == "__main__":
-    mcp.run(transport="stdio")
+    if transport == "http":
+        print(
+            f"Starting BRAIN 3.0 MCP server (streamable-http) on {host}:{port}",
+            file=sys.stderr,
+        )
+        mcp.run(transport="streamable-http")
+    else:
+        print("Starting BRAIN 3.0 MCP server (stdio)", file=sys.stderr)
+        mcp.run(transport="stdio")


### PR DESCRIPTION
Closes #37

## Summary
Adds streamable HTTP as an alternative transport mode to the brain3-mcp server. The server can now run as either a stdio subprocess (existing behavior) or a network-accessible HTTP server, controlled via environment variables.

## Changes
- **`mcp/server.py`** — Added transport mode selection via `MCP_TRANSPORT` env var (`stdio` default, `http` for streamable HTTP). Host and port configurable via `MCP_HOST` (default `0.0.0.0`) and `MCP_PORT` (default `8001`). Startup logs transport mode to stderr (avoids corrupting stdio protocol). Updated module docstring to reflect dual-transport support.

## How to Verify
1. `python mcp/server.py` — starts in stdio mode (default, no regression)
2. `MCP_TRANSPORT=stdio python mcp/server.py` — starts in stdio mode (explicit)
3. `MCP_TRANSPORT=http python mcp/server.py` — starts streamable HTTP on `0.0.0.0:8001`
4. `MCP_TRANSPORT=http MCP_PORT=9000 python mcp/server.py` — starts on port 9000
5. `curl -X POST http://localhost:8001/mcp -H "Content-Type: application/json" -H "Accept: application/json, text/event-stream" -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"0.1.0"}}}'` — returns valid MCP initialize response
6. `health_check` tool works on both transports

## Deviations
- **Startup log uses `sys.stderr` instead of `print()` to stdout.** The issue pseudocode used bare `print()`, but in stdio mode stdout is the MCP transport channel — writing to it corrupts the protocol. Using stderr keeps logs visible without interfering with either transport.
- **`host` and `port` are passed to `FastMCP()` constructor** rather than `mcp.run()` kwargs. The MCP SDK v1.26.0 reads host/port from `self.settings` (set at construction), not from `run()` arguments. The issue's pseudocode showed `mcp.run(transport="streamable-http", host=host, port=port)` which raises `TypeError`.

## Test Results
```
$ python -m pytest tests/ -v
32 passed in 0.23s
```
All existing tests pass. stdio and HTTP modes verified manually per steps above.

## Acceptance Checklist
- [x] `MCP_TRANSPORT` env var with `stdio` (default) and `http` values
- [x] HTTP mode starts streamable HTTP server on configurable host/port
- [x] stdio mode unchanged — zero regression
- [x] `MCP_HOST` configurable (default `0.0.0.0`)
- [x] `MCP_PORT` configurable (default `8001`)
- [x] MCP endpoint at `/mcp` (SDK default)
- [x] All tools available on both transports
- [x] `health_check` confirms API connectivity on both transports
- [x] Startup log indicates transport mode