### PR TITLE
2F-05: MCP tools for rules engine

### DIFF
--- a/mcp/tests/test_rules.py
+++ b/mcp/tests/test_rules.py
@@ -1,0 +1,422 @@
+"""Tests for rules engine MCP tools."""
+
+import pytest
+from unittest.mock import AsyncMock
+
+from client import BrainAPIError
+from mcp.server.fastmcp import FastMCP
+from tools.rules import register
+from validation import InputValidationError
+from tests.conftest import make_api_error
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+VALID_UUID = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+VALID_UUID_2 = "b2c3d4e5-f6a7-8901-bcde-f12345678901"
+
+
+@pytest.fixture()
+def api():
+    return AsyncMock()
+
+
+@pytest.fixture()
+def tools(api):
+    """Register rules tools and return a dict of tool functions."""
+    mcp = FastMCP("test")
+    register(mcp, api)
+    return {
+        name: tool.fn
+        for name, tool in mcp._tool_manager._tools.items()
+    }
+
+
+# ---------------------------------------------------------------------------
+# create_rule
+# ---------------------------------------------------------------------------
+
+class TestCreateRule:
+
+    @pytest.mark.anyio
+    async def test_happy_path(self, tools, api):
+        api.post.return_value = {"id": VALID_UUID, "name": "Skip alert"}
+        result = await tools["create_rule"](
+            name="Skip alert",
+            entity_type="habit",
+            metric="consecutive_skips",
+            operator="gte",
+            threshold=3,
+            notification_type="habit_nudge",
+            message_template="{entity_name} has been skipped {metric_value} times",
+        )
+        assert result["id"] == VALID_UUID
+        api.post.assert_called_once()
+        call_args = api.post.call_args
+        assert call_args[0][0] == "/api/rules/"
+        body = call_args[1]["json"]
+        assert body["name"] == "Skip alert"
+        assert body["entity_type"] == "habit"
+        assert body["metric"] == "consecutive_skips"
+        assert body["operator"] == "gte"
+        assert body["threshold"] == 3
+        assert body["notification_type"] == "habit_nudge"
+        assert body["enabled"] is True
+        assert body["cooldown_hours"] == 24
+
+    @pytest.mark.anyio
+    async def test_with_entity_id(self, tools, api):
+        api.post.return_value = {"id": VALID_UUID}
+        await tools["create_rule"](
+            name="Targeted rule",
+            entity_type="habit",
+            metric="consecutive_skips",
+            operator="gte",
+            threshold=2,
+            notification_type="habit_nudge",
+            message_template="test",
+            entity_id=VALID_UUID_2,
+            enabled=False,
+            cooldown_hours=48,
+        )
+        body = api.post.call_args[1]["json"]
+        assert body["entity_id"] == VALID_UUID_2
+        assert body["enabled"] is False
+        assert body["cooldown_hours"] == 48
+
+    @pytest.mark.anyio
+    async def test_invalid_entity_type(self, tools):
+        with pytest.raises(InputValidationError, match="entity_type"):
+            await tools["create_rule"](
+                name="Bad rule",
+                entity_type="widget",
+                metric="consecutive_skips",
+                operator="gte",
+                threshold=3,
+                notification_type="habit_nudge",
+                message_template="test",
+            )
+
+    @pytest.mark.anyio
+    async def test_invalid_metric(self, tools):
+        with pytest.raises(InputValidationError, match="metric"):
+            await tools["create_rule"](
+                name="Bad rule",
+                entity_type="habit",
+                metric="invalid_metric",
+                operator="gte",
+                threshold=3,
+                notification_type="habit_nudge",
+                message_template="test",
+            )
+
+    @pytest.mark.anyio
+    async def test_invalid_operator(self, tools):
+        with pytest.raises(InputValidationError, match="operator"):
+            await tools["create_rule"](
+                name="Bad rule",
+                entity_type="habit",
+                metric="consecutive_skips",
+                operator="gt",
+                threshold=3,
+                notification_type="habit_nudge",
+                message_template="test",
+            )
+
+    @pytest.mark.anyio
+    async def test_invalid_notification_type(self, tools):
+        with pytest.raises(InputValidationError, match="notification_type"):
+            await tools["create_rule"](
+                name="Bad rule",
+                entity_type="habit",
+                metric="consecutive_skips",
+                operator="gte",
+                threshold=3,
+                notification_type="invalid_type",
+                message_template="test",
+            )
+
+    @pytest.mark.anyio
+    async def test_negative_threshold(self, tools):
+        with pytest.raises(InputValidationError, match="threshold"):
+            await tools["create_rule"](
+                name="Bad rule",
+                entity_type="habit",
+                metric="consecutive_skips",
+                operator="gte",
+                threshold=-1,
+                notification_type="habit_nudge",
+                message_template="test",
+            )
+
+    @pytest.mark.anyio
+    async def test_negative_cooldown(self, tools):
+        with pytest.raises(InputValidationError, match="cooldown_hours"):
+            await tools["create_rule"](
+                name="Bad rule",
+                entity_type="habit",
+                metric="consecutive_skips",
+                operator="gte",
+                threshold=3,
+                notification_type="habit_nudge",
+                message_template="test",
+                cooldown_hours=-1,
+            )
+
+    @pytest.mark.anyio
+    async def test_missing_name(self, tools):
+        with pytest.raises(InputValidationError, match="name"):
+            await tools["create_rule"](
+                name="",
+                entity_type="habit",
+                metric="consecutive_skips",
+                operator="gte",
+                threshold=3,
+                notification_type="habit_nudge",
+                message_template="test",
+            )
+
+    @pytest.mark.anyio
+    async def test_invalid_entity_id_uuid(self, tools):
+        with pytest.raises(InputValidationError, match="entity_id"):
+            await tools["create_rule"](
+                name="Bad rule",
+                entity_type="habit",
+                metric="consecutive_skips",
+                operator="gte",
+                threshold=3,
+                notification_type="habit_nudge",
+                message_template="test",
+                entity_id="not-a-uuid",
+            )
+
+
+# ---------------------------------------------------------------------------
+# list_rules
+# ---------------------------------------------------------------------------
+
+class TestListRules:
+
+    @pytest.mark.anyio
+    async def test_no_filters(self, tools, api):
+        api.get.return_value = []
+        result = await tools["list_rules"]()
+        assert result == []
+        api.get.assert_called_once_with("/api/rules/", params=None)
+
+    @pytest.mark.anyio
+    async def test_all_filters(self, tools, api):
+        api.get.return_value = [{"id": VALID_UUID}]
+        await tools["list_rules"](
+            entity_type="habit",
+            enabled=True,
+            notification_type="habit_nudge",
+            entity_id=VALID_UUID,
+        )
+        call_params = api.get.call_args[1]["params"]
+        assert call_params["entity_type"] == "habit"
+        assert call_params["enabled"] is True
+        assert call_params["notification_type"] == "habit_nudge"
+        assert call_params["entity_id"] == VALID_UUID
+
+    @pytest.mark.anyio
+    async def test_invalid_entity_type_filter(self, tools):
+        with pytest.raises(InputValidationError, match="entity_type"):
+            await tools["list_rules"](entity_type="invalid")
+
+    @pytest.mark.anyio
+    async def test_invalid_notification_type_filter(self, tools):
+        with pytest.raises(InputValidationError, match="notification_type"):
+            await tools["list_rules"](notification_type="bogus")
+
+    @pytest.mark.anyio
+    async def test_invalid_entity_id_filter(self, tools):
+        with pytest.raises(InputValidationError, match="entity_id"):
+            await tools["list_rules"](entity_id="bad-uuid")
+
+
+# ---------------------------------------------------------------------------
+# get_rule
+# ---------------------------------------------------------------------------
+
+class TestGetRule:
+
+    @pytest.mark.anyio
+    async def test_happy_path(self, tools, api):
+        api.get.return_value = {"id": VALID_UUID, "name": "Skip alert"}
+        result = await tools["get_rule"](rule_id=VALID_UUID)
+        assert result["id"] == VALID_UUID
+        api.get.assert_called_once_with(f"/api/rules/{VALID_UUID}")
+
+    @pytest.mark.anyio
+    async def test_invalid_uuid(self, tools):
+        with pytest.raises(InputValidationError, match="rule_id"):
+            await tools["get_rule"](rule_id="bad")
+
+    @pytest.mark.anyio
+    async def test_not_found(self, tools, api):
+        api.get.side_effect = make_api_error(404, "Rule not found")
+        with pytest.raises(BrainAPIError, match="404"):
+            await tools["get_rule"](rule_id=VALID_UUID)
+
+
+# ---------------------------------------------------------------------------
+# update_rule
+# ---------------------------------------------------------------------------
+
+class TestUpdateRule:
+
+    @pytest.mark.anyio
+    async def test_happy_path(self, tools, api):
+        api.patch.return_value = {"id": VALID_UUID, "threshold": 5}
+        result = await tools["update_rule"](
+            rule_id=VALID_UUID,
+            threshold=5,
+        )
+        assert result["threshold"] == 5
+        call_args = api.patch.call_args
+        assert call_args[0][0] == f"/api/rules/{VALID_UUID}"
+        assert call_args[1]["json"]["threshold"] == 5
+
+    @pytest.mark.anyio
+    async def test_multiple_fields(self, tools, api):
+        api.patch.return_value = {"id": VALID_UUID}
+        await tools["update_rule"](
+            rule_id=VALID_UUID,
+            name="Updated name",
+            enabled=False,
+            cooldown_hours=48,
+        )
+        body = api.patch.call_args[1]["json"]
+        assert body["name"] == "Updated name"
+        assert body["enabled"] is False
+        assert body["cooldown_hours"] == 48
+
+    @pytest.mark.anyio
+    async def test_invalid_uuid(self, tools):
+        with pytest.raises(InputValidationError, match="rule_id"):
+            await tools["update_rule"](rule_id="bad")
+
+    @pytest.mark.anyio
+    async def test_invalid_entity_type(self, tools):
+        with pytest.raises(InputValidationError, match="entity_type"):
+            await tools["update_rule"](
+                rule_id=VALID_UUID, entity_type="invalid"
+            )
+
+    @pytest.mark.anyio
+    async def test_invalid_metric(self, tools):
+        with pytest.raises(InputValidationError, match="metric"):
+            await tools["update_rule"](
+                rule_id=VALID_UUID, metric="bad_metric"
+            )
+
+    @pytest.mark.anyio
+    async def test_invalid_operator(self, tools):
+        with pytest.raises(InputValidationError, match="operator"):
+            await tools["update_rule"](
+                rule_id=VALID_UUID, operator="neq"
+            )
+
+    @pytest.mark.anyio
+    async def test_negative_threshold(self, tools):
+        with pytest.raises(InputValidationError, match="threshold"):
+            await tools["update_rule"](
+                rule_id=VALID_UUID, threshold=-1
+            )
+
+    @pytest.mark.anyio
+    async def test_negative_cooldown(self, tools):
+        with pytest.raises(InputValidationError, match="cooldown_hours"):
+            await tools["update_rule"](
+                rule_id=VALID_UUID, cooldown_hours=-5
+            )
+
+    @pytest.mark.anyio
+    async def test_not_found(self, tools, api):
+        api.patch.side_effect = make_api_error(404, "Rule not found")
+        with pytest.raises(BrainAPIError, match="404"):
+            await tools["update_rule"](
+                rule_id=VALID_UUID, threshold=5
+            )
+
+
+# ---------------------------------------------------------------------------
+# delete_rule
+# ---------------------------------------------------------------------------
+
+class TestDeleteRule:
+
+    @pytest.mark.anyio
+    async def test_happy_path(self, tools, api):
+        api.delete.return_value = {"deleted": True}
+        result = await tools["delete_rule"](rule_id=VALID_UUID)
+        assert result["deleted"] is True
+        api.delete.assert_called_once_with(f"/api/rules/{VALID_UUID}")
+
+    @pytest.mark.anyio
+    async def test_invalid_uuid(self, tools):
+        with pytest.raises(InputValidationError, match="rule_id"):
+            await tools["delete_rule"](rule_id="bad")
+
+    @pytest.mark.anyio
+    async def test_not_found(self, tools, api):
+        api.delete.side_effect = make_api_error(404, "Rule not found")
+        with pytest.raises(BrainAPIError, match="404"):
+            await tools["delete_rule"](rule_id=VALID_UUID)
+
+
+# ---------------------------------------------------------------------------
+# evaluate_rules
+# ---------------------------------------------------------------------------
+
+class TestEvaluateRules:
+
+    @pytest.mark.anyio
+    async def test_happy_path(self, tools, api):
+        api.post.return_value = {
+            "evaluated": 5, "fired": 2, "skipped": 3, "results": [],
+        }
+        result = await tools["evaluate_rules"]()
+        assert result["evaluated"] == 5
+        assert result["fired"] == 2
+        api.post.assert_called_once_with("/api/rules/evaluate")
+
+
+# ---------------------------------------------------------------------------
+# evaluate_rule
+# ---------------------------------------------------------------------------
+
+class TestEvaluateRule:
+
+    @pytest.mark.anyio
+    async def test_happy_path(self, tools, api):
+        api.post.return_value = {"rule_id": VALID_UUID, "fired": True}
+        result = await tools["evaluate_rule"](rule_id=VALID_UUID)
+        assert result["fired"] is True
+        call_args = api.post.call_args
+        assert call_args[0][0] == f"/api/rules/{VALID_UUID}/evaluate"
+        assert call_args[1]["params"]["respect_cooldown"] is True
+
+    @pytest.mark.anyio
+    async def test_bypass_cooldown(self, tools, api):
+        api.post.return_value = {"rule_id": VALID_UUID, "fired": True}
+        await tools["evaluate_rule"](
+            rule_id=VALID_UUID,
+            respect_cooldown=False,
+        )
+        call_params = api.post.call_args[1]["params"]
+        assert call_params["respect_cooldown"] is False
+
+    @pytest.mark.anyio
+    async def test_invalid_uuid(self, tools):
+        with pytest.raises(InputValidationError, match="rule_id"):
+            await tools["evaluate_rule"](rule_id="bad")
+
+    @pytest.mark.anyio
+    async def test_not_found(self, tools, api):
+        api.post.side_effect = make_api_error(404, "Rule not found")
+        with pytest.raises(BrainAPIError, match="404"):
+            await tools["evaluate_rule"](rule_id=VALID_UUID)

--- a/mcp/tools/__init__.py
+++ b/mcp/tools/__init__.py
@@ -20,6 +20,7 @@ from tools.directives import register as register_directives
 from tools.skills import register as register_skills
 from tools.notifications import register as register_notifications
 from tools.batch import register as register_batch
+from tools.rules import register as register_rules
 
 
 def register_all(mcp, api) -> None:
@@ -40,3 +41,4 @@ def register_all(mcp, api) -> None:
     register_skills(mcp, api)
     register_notifications(mcp, api)
     register_batch(mcp, api)
+    register_rules(mcp, api)

--- a/mcp/tools/rules.py
+++ b/mcp/tools/rules.py
@@ -1,0 +1,212 @@
+"""Rules engine CRUD and evaluation tools."""
+
+from validation import (
+    InputValidationError,
+    validate_enum,
+    validate_uuid,
+    validate_required_str,
+    RULE_ENTITY_TYPES,
+    RULE_METRICS,
+    RULE_OPERATORS,
+    NOTIFICATION_TYPES,
+)
+from tools._helpers import params, strip_nones
+
+
+def register(mcp, api) -> None:
+    """Register rules engine tools with the MCP server."""
+
+    @mcp.tool()
+    async def create_rule(
+        name: str,
+        entity_type: str,
+        metric: str,
+        operator: str,
+        threshold: int,
+        notification_type: str,
+        message_template: str,
+        entity_id: str | None = None,
+        enabled: bool = True,
+        cooldown_hours: int = 24,
+    ) -> dict:
+        """Create a new rule in the BRAIN rules engine.
+
+        Rules are simple conditional logic: when a metric on an entity type
+        meets a threshold, create a notification. Use this to set up
+        automated nudges, alerts, and pattern-based interventions.
+
+        Available metrics: consecutive_skips, days_untouched,
+        non_responses, streak_length.
+        Operators: >= (gte), <= (lte), == (eq).
+
+        Message templates support placeholders: {entity_name},
+        {entity_type}, {metric_value}, {threshold}, {rule_name}.
+
+        Set entity_id to target a specific entity, or omit it for a
+        rule that applies to all entities of that type.
+        """
+        validate_required_str(name, "name")
+        validate_required_str(entity_type, "entity_type")
+        validate_required_str(metric, "metric")
+        validate_required_str(operator, "operator")
+        validate_required_str(notification_type, "notification_type")
+        validate_required_str(message_template, "message_template")
+        validate_enum(entity_type, "entity_type", RULE_ENTITY_TYPES)
+        validate_enum(metric, "metric", RULE_METRICS)
+        validate_enum(operator, "operator", RULE_OPERATORS)
+        validate_enum(notification_type, "notification_type", NOTIFICATION_TYPES)
+        validate_uuid(entity_id, "entity_id")
+        if not isinstance(threshold, int) or threshold < 0:
+            raise InputValidationError(
+                f"Invalid threshold: {threshold}. Must be a non-negative integer."
+            )
+        if cooldown_hours < 0:
+            raise InputValidationError(
+                f"Invalid cooldown_hours: {cooldown_hours}. "
+                "Must be a non-negative integer."
+            )
+        body = strip_nones({
+            "name": name,
+            "entity_type": entity_type,
+            "metric": metric,
+            "operator": operator,
+            "threshold": threshold,
+            "notification_type": notification_type,
+            "message_template": message_template,
+            "entity_id": entity_id,
+            "enabled": enabled,
+            "cooldown_hours": cooldown_hours,
+        })
+        return await api.post("/api/rules/", json=body)
+
+    @mcp.tool()
+    async def list_rules(
+        entity_type: str | None = None,
+        enabled: bool | None = None,
+        notification_type: str | None = None,
+        entity_id: str | None = None,
+    ) -> list:
+        """List rules with optional filters.
+
+        Use to review what rules exist and their current state. All filter
+        parameters are optional and combine with AND logic.
+
+        Common patterns:
+        - Review active rules: enabled=true
+        - Rules for a specific entity type: entity_type="habit"
+        - Rules targeting a specific entity: entity_id=<uuid>
+        """
+        validate_enum(entity_type, "entity_type", RULE_ENTITY_TYPES)
+        validate_enum(notification_type, "notification_type", NOTIFICATION_TYPES)
+        validate_uuid(entity_id, "entity_id")
+        return await api.get(
+            "/api/rules/",
+            params=params(
+                entity_type=entity_type,
+                enabled=enabled,
+                notification_type=notification_type,
+                entity_id=entity_id,
+            ),
+        )
+
+    @mcp.tool()
+    async def get_rule(rule_id: str) -> dict:
+        """Get a single rule by ID.
+
+        Returns full rule details including last_triggered_at, enabled
+        status, and all configuration. Use this to inspect a specific
+        rule's current state before tuning or testing it.
+        """
+        validate_uuid(rule_id, "rule_id")
+        return await api.get(f"/api/rules/{rule_id}")
+
+    @mcp.tool()
+    async def update_rule(
+        rule_id: str,
+        name: str | None = None,
+        entity_type: str | None = None,
+        metric: str | None = None,
+        operator: str | None = None,
+        threshold: int | None = None,
+        notification_type: str | None = None,
+        message_template: str | None = None,
+        entity_id: str | None = None,
+        enabled: bool | None = None,
+        cooldown_hours: int | None = None,
+    ) -> dict:
+        """Update an existing rule.
+
+        All fields are optional — only provided fields are changed. Use to
+        tune thresholds, adjust cooldowns, enable/disable rules, or update
+        message templates.
+        """
+        validate_uuid(rule_id, "rule_id")
+        validate_enum(entity_type, "entity_type", RULE_ENTITY_TYPES)
+        validate_enum(metric, "metric", RULE_METRICS)
+        validate_enum(operator, "operator", RULE_OPERATORS)
+        validate_enum(notification_type, "notification_type", NOTIFICATION_TYPES)
+        validate_uuid(entity_id, "entity_id")
+        if threshold is not None and (not isinstance(threshold, int) or threshold < 0):
+            raise InputValidationError(
+                f"Invalid threshold: {threshold}. Must be a non-negative integer."
+            )
+        if cooldown_hours is not None and cooldown_hours < 0:
+            raise InputValidationError(
+                f"Invalid cooldown_hours: {cooldown_hours}. "
+                "Must be a non-negative integer."
+            )
+        body = strip_nones({
+            "name": name,
+            "entity_type": entity_type,
+            "metric": metric,
+            "operator": operator,
+            "threshold": threshold,
+            "notification_type": notification_type,
+            "message_template": message_template,
+            "entity_id": entity_id,
+            "enabled": enabled,
+            "cooldown_hours": cooldown_hours,
+        })
+        return await api.patch(f"/api/rules/{rule_id}", json=body)
+
+    @mcp.tool()
+    async def delete_rule(rule_id: str) -> dict:
+        """Delete a rule.
+
+        Historical notifications created by this rule are preserved but
+        their rule_id link is cleared. Confirm with the user before
+        deleting.
+        """
+        validate_uuid(rule_id, "rule_id")
+        return await api.delete(f"/api/rules/{rule_id}")
+
+    @mcp.tool()
+    async def evaluate_rules() -> dict:
+        """Evaluate all enabled rules now.
+
+        Checks each rule's condition against current BRAIN data, respects
+        cooldowns, and creates notifications for rules that fire. Returns
+        a summary of what fired and what was skipped.
+
+        The scheduler calls this automatically, but you can trigger it
+        manually during a session to check rule behavior or after making
+        changes to rules.
+        """
+        return await api.post("/api/rules/evaluate")
+
+    @mcp.tool()
+    async def evaluate_rule(
+        rule_id: str,
+        respect_cooldown: bool = True,
+    ) -> dict:
+        """Evaluate a single rule.
+
+        Useful for testing a rule you just created or modified. Set
+        respect_cooldown=false to bypass cooldown during testing — the
+        rule will fire even if it was recently triggered.
+        """
+        validate_uuid(rule_id, "rule_id")
+        return await api.post(
+            f"/api/rules/{rule_id}/evaluate",
+            params=params(respect_cooldown=respect_cooldown),
+        )

--- a/mcp/validation.py
+++ b/mcp/validation.py
@@ -51,6 +51,9 @@ NOTIFICATION_STATUSES = {"pending", "delivered", "responded", "expired"}
 DELIVERY_TYPES = {"notification"}
 SCHEDULED_BY_VALUES = {"system", "claude", "rule"}
 TARGET_ENTITY_TYPES = {"habit", "routine", "task", "checkin", "goal", "project"}
+RULE_ENTITY_TYPES = {"habit", "routine", "task", "goal", "project"}
+RULE_METRICS = {"consecutive_skips", "days_untouched", "non_responses", "streak_length"}
+RULE_OPERATORS = {"gte", "lte", "eq"}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Adds 7 MCP tools wrapping the brain3 rules engine API endpoints, completing Stream F. Claude now has full read/write/evaluate access to rules during sessions — the primary interface for creating, tuning, and testing notification rules.

## Changes
- **`mcp/tools/rules.py`** — New module with 7 tools: `create_rule`, `list_rules`, `get_rule`, `update_rule`, `delete_rule`, `evaluate_rules`, `evaluate_rule`. Follows existing tool registration pattern with `@mcp.tool()` decorators inside a `register(mcp, api)` function.
- **`mcp/validation.py`** — Added 3 enum sets: `RULE_ENTITY_TYPES`, `RULE_METRICS`, `RULE_OPERATORS` for pre-request validation.
- **`mcp/tools/__init__.py`** — Registered the rules module in `register_all()`.
- **`mcp/tests/test_rules.py`** — 35 tests covering all 7 tools: happy paths, all filter combinations, validation errors (invalid enums, UUIDs, thresholds, cooldowns), and API error propagation (404s).

Total tool count: 120 → 127.

## How to Verify
1. `cd mcp && python -m pytest tests/test_rules.py -v` — 35 tests pass
2. `python -m pytest tests/ -v` — full suite (75 tests) passes
3. `ruff check mcp/` — clean
4. Verify tool registration:
   ```python
   from mcp.server.fastmcp import FastMCP
   from unittest.mock import AsyncMock
   from tools import register_all
   server = FastMCP('test'); api = AsyncMock()
   register_all(server, api)
   rules = [t for t in server._tool_manager._tools if 'rule' in t]
   assert len(rules) == 7
   ```

## Deviations
None. All 7 tools match the spec definitions exactly.

## Test Results
```
75 passed in 1.69s (35 rules + 40 existing)
ruff: All checks passed!
```

## Acceptance Checklist
- [x] 7 MCP tools registered and functional
- [x] Each tool maps to its corresponding brain3 API endpoint
- [x] Tool descriptions include placeholder syntax and available metrics
- [x] `list_rules` filter parameters match API: entity_type, enabled, notification_type, entity_id
- [x] `evaluate_rule` exposes respect_cooldown parameter
- [x] Tests cover happy paths, validation, filters, and error propagation

Closes #50