### PR TITLE
feat(stream-g): [2G-07] MCP Tools — Graduation, Frequency & Stacking

### DIFF
--- a/mcp/tests/test_graduation.py
+++ b/mcp/tests/test_graduation.py
@@ -1,0 +1,463 @@
+"""Tests for graduation, frequency, and stacking MCP tools."""
+
+import pytest
+from unittest.mock import AsyncMock
+
+from client import BrainAPIError
+from mcp.server.fastmcp import FastMCP
+from tools.graduation import register
+from validation import InputValidationError
+from tests.conftest import make_api_error
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+VALID_UUID = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+VALID_UUID_2 = "b2c3d4e5-f6a7-8901-bcde-f12345678901"
+
+
+@pytest.fixture()
+def api():
+    return AsyncMock()
+
+
+@pytest.fixture()
+def tools(api):
+    """Register graduation tools and return a dict of tool functions."""
+    mcp = FastMCP("test")
+    register(mcp, api)
+    return {
+        name: tool.fn
+        for name, tool in mcp._tool_manager._tools.items()
+    }
+
+
+# ---------------------------------------------------------------------------
+# evaluate_graduation
+# ---------------------------------------------------------------------------
+
+class TestEvaluateGraduation:
+
+    @pytest.mark.anyio
+    async def test_happy_path(self, tools, api):
+        api.post.return_value = {
+            "eligible": True,
+            "current_rate": 0.85,
+            "target_rate": 0.80,
+            "days_since_introduction": 30,
+            "blocking_reasons": [],
+        }
+        result = await tools["evaluate_graduation"](habit_id=VALID_UUID)
+        assert result["eligible"] is True
+        assert result["current_rate"] == 0.85
+        api.post.assert_called_once_with(
+            f"/api/habits/{VALID_UUID}/evaluate-graduation"
+        )
+
+    @pytest.mark.anyio
+    async def test_invalid_uuid(self, tools, api):
+        with pytest.raises(InputValidationError, match="not a valid UUID"):
+            await tools["evaluate_graduation"](habit_id="not-a-uuid")
+
+    @pytest.mark.anyio
+    async def test_not_found(self, tools, api):
+        api.post.side_effect = make_api_error(404, "Habit not found")
+        with pytest.raises(BrainAPIError, match="404"):
+            await tools["evaluate_graduation"](habit_id=VALID_UUID)
+
+
+# ---------------------------------------------------------------------------
+# graduate_habit
+# ---------------------------------------------------------------------------
+
+class TestGraduateHabit:
+
+    @pytest.mark.anyio
+    async def test_happy_path(self, tools, api):
+        api.post.return_value = {
+            "success": True,
+            "previous_state": "accountable",
+            "new_state": "graduated",
+        }
+        result = await tools["graduate_habit"](habit_id=VALID_UUID)
+        assert result["success"] is True
+        api.post.assert_called_once_with(
+            f"/api/habits/{VALID_UUID}/graduate", json=None
+        )
+
+    @pytest.mark.anyio
+    async def test_with_force(self, tools, api):
+        api.post.return_value = {"success": True}
+        await tools["graduate_habit"](habit_id=VALID_UUID, force=True)
+        call_args = api.post.call_args
+        assert call_args[1]["json"]["force"] is True
+
+    @pytest.mark.anyio
+    async def test_invalid_uuid(self, tools, api):
+        with pytest.raises(InputValidationError, match="not a valid UUID"):
+            await tools["graduate_habit"](habit_id="bad")
+
+    @pytest.mark.anyio
+    async def test_not_eligible(self, tools, api):
+        api.post.side_effect = make_api_error(
+            400, "Habit does not meet graduation criteria"
+        )
+        with pytest.raises(BrainAPIError, match="400"):
+            await tools["graduate_habit"](habit_id=VALID_UUID)
+
+
+# ---------------------------------------------------------------------------
+# evaluate_frequency
+# ---------------------------------------------------------------------------
+
+class TestEvaluateFrequency:
+
+    @pytest.mark.anyio
+    async def test_happy_path(self, tools, api):
+        api.post.return_value = {
+            "recommendation": "step_down",
+            "current_frequency": "daily",
+            "recommended_frequency": "every_other_day",
+            "rate": 0.90,
+            "cooldown_active": False,
+        }
+        result = await tools["evaluate_frequency"](habit_id=VALID_UUID)
+        assert result["recommendation"] == "step_down"
+        api.post.assert_called_once_with(
+            f"/api/habits/{VALID_UUID}/evaluate-frequency"
+        )
+
+    @pytest.mark.anyio
+    async def test_invalid_uuid(self, tools, api):
+        with pytest.raises(InputValidationError, match="not a valid UUID"):
+            await tools["evaluate_frequency"](habit_id="nope")
+
+    @pytest.mark.anyio
+    async def test_not_found(self, tools, api):
+        api.post.side_effect = make_api_error(404, "Habit not found")
+        with pytest.raises(BrainAPIError, match="404"):
+            await tools["evaluate_frequency"](habit_id=VALID_UUID)
+
+
+# ---------------------------------------------------------------------------
+# step_down_frequency
+# ---------------------------------------------------------------------------
+
+class TestStepDownFrequency:
+
+    @pytest.mark.anyio
+    async def test_happy_path(self, tools, api):
+        api.post.return_value = {
+            "success": True,
+            "previous_frequency": "daily",
+            "new_frequency": "every_other_day",
+        }
+        result = await tools["step_down_frequency"](habit_id=VALID_UUID)
+        assert result["success"] is True
+        assert result["new_frequency"] == "every_other_day"
+        api.post.assert_called_once_with(
+            f"/api/habits/{VALID_UUID}/step-down-frequency"
+        )
+
+    @pytest.mark.anyio
+    async def test_invalid_uuid(self, tools, api):
+        with pytest.raises(InputValidationError, match="not a valid UUID"):
+            await tools["step_down_frequency"](habit_id="bad-id")
+
+    @pytest.mark.anyio
+    async def test_not_recommended(self, tools, api):
+        api.post.side_effect = make_api_error(
+            400, "Step-down not recommended"
+        )
+        with pytest.raises(BrainAPIError, match="400"):
+            await tools["step_down_frequency"](habit_id=VALID_UUID)
+
+
+# ---------------------------------------------------------------------------
+# evaluate_slip
+# ---------------------------------------------------------------------------
+
+class TestEvaluateSlip:
+
+    @pytest.mark.anyio
+    async def test_happy_path(self, tools, api):
+        api.post.return_value = {
+            "slip_signals": [],
+            "recommendation": "no_action",
+            "days_since_graduation": 14,
+        }
+        result = await tools["evaluate_slip"](habit_id=VALID_UUID)
+        assert result["recommendation"] == "no_action"
+        api.post.assert_called_once_with(
+            f"/api/habits/{VALID_UUID}/evaluate-slip"
+        )
+
+    @pytest.mark.anyio
+    async def test_with_slip_detected(self, tools, api):
+        api.post.return_value = {
+            "slip_signals": [
+                {"type": "checklist_gap", "severity": "moderate"},
+            ],
+            "recommendation": "re_scaffold",
+            "days_since_graduation": 7,
+        }
+        result = await tools["evaluate_slip"](habit_id=VALID_UUID)
+        assert result["recommendation"] == "re_scaffold"
+        assert len(result["slip_signals"]) == 1
+
+    @pytest.mark.anyio
+    async def test_invalid_uuid(self, tools, api):
+        with pytest.raises(InputValidationError, match="not a valid UUID"):
+            await tools["evaluate_slip"](habit_id="x")
+
+    @pytest.mark.anyio
+    async def test_not_graduated(self, tools, api):
+        api.post.side_effect = make_api_error(
+            400, "Habit is not graduated"
+        )
+        with pytest.raises(BrainAPIError, match="400"):
+            await tools["evaluate_slip"](habit_id=VALID_UUID)
+
+
+# ---------------------------------------------------------------------------
+# re_scaffold_habit
+# ---------------------------------------------------------------------------
+
+class TestReScaffoldHabit:
+
+    @pytest.mark.anyio
+    async def test_happy_path(self, tools, api):
+        api.post.return_value = {
+            "new_scaffolding_state": "accountable",
+            "re_scaffold_count": 1,
+            "tightened_criteria": {
+                "graduation_target": 0.90,
+                "graduation_window": 21,
+            },
+        }
+        result = await tools["re_scaffold_habit"](habit_id=VALID_UUID)
+        assert result["new_scaffolding_state"] == "accountable"
+        assert result["re_scaffold_count"] == 1
+        api.post.assert_called_once_with(
+            f"/api/habits/{VALID_UUID}/re-scaffold"
+        )
+
+    @pytest.mark.anyio
+    async def test_invalid_uuid(self, tools, api):
+        with pytest.raises(InputValidationError, match="not a valid UUID"):
+            await tools["re_scaffold_habit"](habit_id="nah")
+
+    @pytest.mark.anyio
+    async def test_not_graduated(self, tools, api):
+        api.post.side_effect = make_api_error(
+            400, "Habit is not graduated"
+        )
+        with pytest.raises(BrainAPIError, match="400"):
+            await tools["re_scaffold_habit"](habit_id=VALID_UUID)
+
+
+# ---------------------------------------------------------------------------
+# get_graduation_status
+# ---------------------------------------------------------------------------
+
+class TestGetGraduationStatus:
+
+    @pytest.mark.anyio
+    async def test_happy_path(self, tools, api):
+        api.get.return_value = {
+            "habit_id": VALID_UUID,
+            "scaffolding_status": "accountable",
+            "notification_frequency": "daily",
+            "graduation_progress": {
+                "current_rate": 0.75,
+                "target_rate": 0.80,
+                "eligible": False,
+            },
+            "frequency_step_down": {
+                "eligible": False,
+                "cooldown_active": True,
+            },
+            "re_scaffold_count": 0,
+        }
+        result = await tools["get_graduation_status"](habit_id=VALID_UUID)
+        assert result["scaffolding_status"] == "accountable"
+        assert result["graduation_progress"]["current_rate"] == 0.75
+        api.get.assert_called_once_with(
+            f"/api/habits/{VALID_UUID}/graduation-status"
+        )
+
+    @pytest.mark.anyio
+    async def test_invalid_uuid(self, tools, api):
+        with pytest.raises(InputValidationError, match="not a valid UUID"):
+            await tools["get_graduation_status"](habit_id="bad")
+
+    @pytest.mark.anyio
+    async def test_not_found(self, tools, api):
+        api.get.side_effect = make_api_error(404, "Habit not found")
+        with pytest.raises(BrainAPIError, match="404"):
+            await tools["get_graduation_status"](habit_id=VALID_UUID)
+
+
+# ---------------------------------------------------------------------------
+# get_stacking_recommendation
+# ---------------------------------------------------------------------------
+
+class TestGetStackingRecommendation:
+
+    @pytest.mark.anyio
+    async def test_happy_path(self, tools, api):
+        api.get.return_value = {
+            "ready": True,
+            "blocking_habits": [],
+            "suggested_habit": {
+                "id": VALID_UUID_2,
+                "title": "Flossing",
+                "reason": "paused_retry",
+            },
+            "message": "You've been solid -- ready to add flossing?",
+        }
+        result = await tools["get_stacking_recommendation"](
+            routine_id=VALID_UUID
+        )
+        assert result["ready"] is True
+        assert result["suggested_habit"]["title"] == "Flossing"
+        api.get.assert_called_once_with(
+            "/api/graduation/suggest-next",
+            params={"routine_id": VALID_UUID},
+        )
+
+    @pytest.mark.anyio
+    async def test_not_ready(self, tools, api):
+        api.get.return_value = {
+            "ready": False,
+            "blocking_habits": [
+                {"id": VALID_UUID_2, "title": "Brushing teeth"},
+            ],
+            "suggested_habit": None,
+            "message": "Hold steady -- brushing teeth needs more time.",
+        }
+        result = await tools["get_stacking_recommendation"](
+            routine_id=VALID_UUID
+        )
+        assert result["ready"] is False
+        assert len(result["blocking_habits"]) == 1
+
+    @pytest.mark.anyio
+    async def test_invalid_uuid(self, tools, api):
+        with pytest.raises(InputValidationError, match="not a valid UUID"):
+            await tools["get_stacking_recommendation"](
+                routine_id="not-uuid"
+            )
+
+    @pytest.mark.anyio
+    async def test_not_found(self, tools, api):
+        api.get.side_effect = make_api_error(404, "Routine not found")
+        with pytest.raises(BrainAPIError, match="404"):
+            await tools["get_stacking_recommendation"](
+                routine_id=VALID_UUID
+            )
+
+
+# ---------------------------------------------------------------------------
+# Integration flow: evaluate_graduation -> graduate_habit
+# ---------------------------------------------------------------------------
+
+class TestGraduationFlow:
+
+    @pytest.mark.anyio
+    async def test_evaluate_then_graduate(self, tools, api):
+        """End-to-end flow: evaluate graduation, then graduate."""
+        api.post.side_effect = [
+            {
+                "eligible": True,
+                "current_rate": 0.85,
+                "target_rate": 0.80,
+                "days_since_introduction": 30,
+                "blocking_reasons": [],
+            },
+            {
+                "success": True,
+                "previous_state": "accountable",
+                "new_state": "graduated",
+            },
+        ]
+        eval_result = await tools["evaluate_graduation"](
+            habit_id=VALID_UUID
+        )
+        assert eval_result["eligible"] is True
+
+        grad_result = await tools["graduate_habit"](habit_id=VALID_UUID)
+        assert grad_result["success"] is True
+        assert api.post.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Integration flow: evaluate_frequency -> step_down_frequency
+# ---------------------------------------------------------------------------
+
+class TestFrequencyFlow:
+
+    @pytest.mark.anyio
+    async def test_evaluate_then_step_down(self, tools, api):
+        """End-to-end flow: evaluate frequency, then step down."""
+        api.post.side_effect = [
+            {
+                "recommendation": "step_down",
+                "current_frequency": "daily",
+                "recommended_frequency": "every_other_day",
+                "rate": 0.90,
+                "cooldown_active": False,
+            },
+            {
+                "success": True,
+                "previous_frequency": "daily",
+                "new_frequency": "every_other_day",
+            },
+        ]
+        eval_result = await tools["evaluate_frequency"](
+            habit_id=VALID_UUID
+        )
+        assert eval_result["recommendation"] == "step_down"
+
+        step_result = await tools["step_down_frequency"](
+            habit_id=VALID_UUID
+        )
+        assert step_result["success"] is True
+        assert api.post.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Integration flow: get_stacking_recommendation with mixed states
+# ---------------------------------------------------------------------------
+
+class TestStackingFlow:
+
+    @pytest.mark.anyio
+    async def test_mixed_habit_states(self, tools, api):
+        """Stacking recommendation with mixed habit states in routine."""
+        api.get.return_value = {
+            "ready": False,
+            "blocking_habits": [
+                {
+                    "id": VALID_UUID,
+                    "title": "Brushing teeth",
+                    "scaffolding_status": "accountable",
+                    "stability": "unstable",
+                },
+            ],
+            "suggested_habit": {
+                "id": VALID_UUID_2,
+                "title": "Flossing",
+                "reason": "paused_retry",
+            },
+            "message": "Brushing teeth isn't stable yet. "
+                       "Hold off on adding flossing.",
+        }
+        result = await tools["get_stacking_recommendation"](
+            routine_id=VALID_UUID
+        )
+        assert result["ready"] is False
+        assert result["blocking_habits"][0]["stability"] == "unstable"
+        assert result["suggested_habit"]["title"] == "Flossing"

--- a/mcp/tools/__init__.py
+++ b/mcp/tools/__init__.py
@@ -21,6 +21,7 @@ from tools.skills import register as register_skills
 from tools.notifications import register as register_notifications
 from tools.batch import register as register_batch
 from tools.rules import register as register_rules
+from tools.graduation import register as register_graduation
 
 
 def register_all(mcp, api) -> None:
@@ -42,3 +43,4 @@ def register_all(mcp, api) -> None:
     register_notifications(mcp, api)
     register_batch(mcp, api)
     register_rules(mcp, api)
+    register_graduation(mcp, api)

--- a/mcp/tools/graduation.py
+++ b/mcp/tools/graduation.py
@@ -1,0 +1,157 @@
+"""Graduation, frequency step-down, and stacking recommendation tools."""
+
+from validation import validate_uuid
+from tools._helpers import params, strip_nones
+
+
+def register(mcp, api) -> None:
+    """Register graduation tools with the MCP server."""
+
+    @mcp.tool()
+    async def evaluate_graduation(habit_id: str) -> dict:
+        """Check if a habit is ready to graduate from active scaffolding.
+
+        Returns the current "already done" rate, progress toward the
+        graduation target, and blocking reasons if not yet eligible. Use
+        this to show the user their progress or to check readiness before
+        recommending graduation.
+
+        When to use: during session reviews, when discussing habit
+        progress, before suggesting graduation. "Let me check how your
+        brushing habit is doing..."
+        """
+        validate_uuid(habit_id, "habit_id")
+        return await api.post(
+            f"/api/habits/{habit_id}/evaluate-graduation"
+        )
+
+    @mcp.tool()
+    async def graduate_habit(
+        habit_id: str,
+        force: bool = False,
+    ) -> dict:
+        """Graduate a habit from active scaffolding.
+
+        Stops individual nudge notifications while keeping the habit in
+        routine checklists. Requires the habit to meet graduation criteria
+        unless force=true.
+
+        Re-scaffolded habits face tighter criteria on subsequent
+        graduations. The default flow is: evaluate_graduation -> discuss
+        with user -> graduate_habit. Use force=true only when the user
+        explicitly agrees despite not meeting criteria.
+        """
+        validate_uuid(habit_id, "habit_id")
+        body = strip_nones({"force": force if force else None})
+        return await api.post(
+            f"/api/habits/{habit_id}/graduate", json=body or None
+        )
+
+    @mcp.tool()
+    async def evaluate_frequency(habit_id: str) -> dict:
+        """Check if a habit's notification frequency should step down.
+
+        Evaluates the "already done" rate over recent notifications and
+        checks cooldown status. Steps go: daily -> every other day ->
+        twice a week -> weekly.
+
+        When to use: during habit check-ins, when the user mentions a
+        habit feels easy, or when reviewing notification settings.
+        "You've been ahead of the reminders -- let me check if we can
+        reduce them."
+        """
+        validate_uuid(habit_id, "habit_id")
+        return await api.post(
+            f"/api/habits/{habit_id}/evaluate-frequency"
+        )
+
+    @mcp.tool()
+    async def step_down_frequency(habit_id: str) -> dict:
+        """Reduce a habit's notification frequency by one level.
+
+        Progression: daily -> every other day -> twice a week -> weekly.
+        Validates that step-down is recommended before applying. Does not
+        skip levels.
+
+        When to use: after reviewing frequency evaluation with the user.
+        Default flow: evaluate_frequency -> discuss -> step_down_frequency.
+        Can also be proactive during session wrap-up: "I noticed your
+        brushing is consistently ahead of reminders -- stepped down to
+        every other day."
+        """
+        validate_uuid(habit_id, "habit_id")
+        return await api.post(
+            f"/api/habits/{habit_id}/step-down-frequency"
+        )
+
+    @mcp.tool()
+    async def evaluate_slip(habit_id: str) -> dict:
+        """Check if a graduated habit shows signs of regression.
+
+        Looks for missed completions and routine checklist gaps. Returns
+        severity-graded slip signals and a recommendation (re-scaffold,
+        monitor, or no action).
+
+        When to use: when reviewing graduated habits during sessions,
+        when the user mentions struggling with a previously-graduated
+        habit, or when reviewing routine checklist partial completions.
+        """
+        validate_uuid(habit_id, "habit_id")
+        return await api.post(
+            f"/api/habits/{habit_id}/evaluate-slip"
+        )
+
+    @mcp.tool()
+    async def re_scaffold_habit(habit_id: str) -> dict:
+        """Reverse graduation and return a habit to daily accountability.
+
+        Used when a graduated habit has slipped. The habit's graduation
+        criteria are tightened for next time -- the system demands
+        stronger evidence before re-graduating. Streaks are preserved.
+
+        When to use: after detecting a slip and discussing with the user.
+        Frame positively: "Re-scaffolding isn't failure -- it means the
+        system is adapting to support you. We'll bring back daily
+        reminders and the bar for next graduation will be a bit higher."
+        """
+        validate_uuid(habit_id, "habit_id")
+        return await api.post(
+            f"/api/habits/{habit_id}/re-scaffold"
+        )
+
+    @mcp.tool()
+    async def get_graduation_status(habit_id: str) -> dict:
+        """Get a habit's full graduation dashboard.
+
+        Returns current scaffolding status, notification frequency,
+        progress toward graduation, frequency step-down eligibility,
+        and re-scaffold history. Use this for comprehensive habit reviews.
+
+        When to use: as the first call when discussing a specific habit's
+        scaffolding journey. Gives all the context in one call instead of
+        needing to run evaluate_graduation + evaluate_frequency separately.
+        """
+        validate_uuid(habit_id, "habit_id")
+        return await api.get(
+            f"/api/habits/{habit_id}/graduation-status"
+        )
+
+    @mcp.tool()
+    async def get_stacking_recommendation(routine_id: str) -> dict:
+        """Check if a routine is ready for a new habit and suggest what to introduce next.
+
+        Evaluates whether all current accountable habits are stable.
+        Recommends paused habits first (give them another shot), then
+        tracking habits (next in the routine's order). One habit at a
+        time prevents the stacking-and-abandoning pattern.
+
+        When to use: during routine reviews, especially when the user is
+        excited about adding habits. The recommendation serves as both a
+        guard ("hold steady, flossing needs more time") and an
+        encouragement ("you've been solid -- ready to add face washing?").
+        """
+        validate_uuid(routine_id, "routine_id")
+        return await api.get(
+            "/api/graduation/suggest-next",
+            params=params(routine_id=routine_id),
+        )


### PR DESCRIPTION
## Summary

Implements 8 MCP tools wrapping the graduation API endpoints from [2G-06]. These tools give Claude conversational access to the graduated scaffolding system — evaluating graduation progress, stepping down notification frequency, detecting slip in graduated habits, re-scaffolding when needed, and recommending when to introduce new habits.

## Changes

**New files:**
- `mcp/tools/graduation.py` — 8 tool definitions following existing registration pattern (evaluate_graduation, graduate_habit, evaluate_frequency, step_down_frequency, evaluate_slip, re_scaffold_habit, get_graduation_status, get_stacking_recommendation)
- `mcp/tests/test_graduation.py` — 30 tests covering happy paths, UUID validation, API error passthrough, and 3 integration flow tests (graduation flow, frequency flow, stacking with mixed states)

**Modified files:**
- `mcp/tools/__init__.py` — Added graduation module import and registration call

## How to Verify

1. Start the BRAIN 3.0 API (with graduation endpoints from 2G-06)
2. Start the MCP server: `cd mcp && python server.py`
3. Verify 8 new tools appear in the tool list
4. Test evaluate_graduation with a valid habit ID
5. Test get_stacking_recommendation with a valid routine ID
6. Run tests: `cd mcp && python -m pytest tests/test_graduation.py -v` (30 pass)
7. Run full suite: `python -m pytest -v` (105 pass, zero regressions)
8. Run linter: `ruff check .` (clean)

## Deviations

None. All 8 tools match the spec exactly. Endpoint paths, parameter types, HTTP methods, and tool naming conventions all align.

## Test Results

```
tests/test_graduation.py — 30 passed in 0.17s
Full suite — 105 passed in 1.32s
ruff check . — All checks passed!
```

## Acceptance Checklist

- [x] All 8 MCP tools are registered and callable via MCP protocol
- [x] Each tool correctly calls its corresponding API endpoint
- [x] Parameter validation matches API expectations (UUIDs, booleans)
- [x] Tool descriptions are clear and include "when to use" guidance for Claude
- [x] Error responses from API are passed through meaningfully (not swallowed)
- [x] Tools work with both local stdio MCP and remote MCP (Stream E) transports
- [x] Integration test: evaluate_graduation → graduate_habit flow works end-to-end via MCP
- [x] Integration test: evaluate_frequency → step_down_frequency flow works end-to-end via MCP
- [x] Integration test: get_stacking_recommendation returns correct data for mixed habit states

Closes #51