### PR TITLE
fix: [2F-Bug-01] Correct operator and entity-type enums in MCP validation

### DIFF
--- a/mcp/tests/test_rules.py
+++ b/mcp/tests/test_rules.py
@@ -47,7 +47,7 @@ class TestCreateRule:
             name="Skip alert",
             entity_type="habit",
             metric="consecutive_skips",
-            operator="gte",
+            operator=">=",
             threshold=3,
             notification_type="habit_nudge",
             message_template="{entity_name} has been skipped {metric_value} times",
@@ -60,7 +60,7 @@ class TestCreateRule:
         assert body["name"] == "Skip alert"
         assert body["entity_type"] == "habit"
         assert body["metric"] == "consecutive_skips"
-        assert body["operator"] == "gte"
+        assert body["operator"] == ">="
         assert body["threshold"] == 3
         assert body["notification_type"] == "habit_nudge"
         assert body["enabled"] is True
@@ -73,7 +73,7 @@ class TestCreateRule:
             name="Targeted rule",
             entity_type="habit",
             metric="consecutive_skips",
-            operator="gte",
+            operator=">=",
             threshold=2,
             notification_type="habit_nudge",
             message_template="test",
@@ -93,7 +93,7 @@ class TestCreateRule:
                 name="Bad rule",
                 entity_type="widget",
                 metric="consecutive_skips",
-                operator="gte",
+                operator=">=",
                 threshold=3,
                 notification_type="habit_nudge",
                 message_template="test",
@@ -106,7 +106,7 @@ class TestCreateRule:
                 name="Bad rule",
                 entity_type="habit",
                 metric="invalid_metric",
-                operator="gte",
+                operator=">=",
                 threshold=3,
                 notification_type="habit_nudge",
                 message_template="test",
@@ -132,7 +132,7 @@ class TestCreateRule:
                 name="Bad rule",
                 entity_type="habit",
                 metric="consecutive_skips",
-                operator="gte",
+                operator=">=",
                 threshold=3,
                 notification_type="invalid_type",
                 message_template="test",
@@ -145,7 +145,7 @@ class TestCreateRule:
                 name="Bad rule",
                 entity_type="habit",
                 metric="consecutive_skips",
-                operator="gte",
+                operator=">=",
                 threshold=-1,
                 notification_type="habit_nudge",
                 message_template="test",
@@ -158,7 +158,7 @@ class TestCreateRule:
                 name="Bad rule",
                 entity_type="habit",
                 metric="consecutive_skips",
-                operator="gte",
+                operator=">=",
                 threshold=3,
                 notification_type="habit_nudge",
                 message_template="test",
@@ -172,7 +172,7 @@ class TestCreateRule:
                 name="",
                 entity_type="habit",
                 metric="consecutive_skips",
-                operator="gte",
+                operator=">=",
                 threshold=3,
                 notification_type="habit_nudge",
                 message_template="test",
@@ -185,12 +185,56 @@ class TestCreateRule:
                 name="Bad rule",
                 entity_type="habit",
                 metric="consecutive_skips",
-                operator="gte",
+                operator=">=",
                 threshold=3,
                 notification_type="habit_nudge",
                 message_template="test",
                 entity_id="not-a-uuid",
             )
+
+    @pytest.mark.anyio
+    async def test_checkin_entity_type_accepted(self, tools, api):
+        api.post.return_value = {"id": VALID_UUID}
+        await tools["create_rule"](
+            name="Checkin rule",
+            entity_type="checkin",
+            metric="non_responses",
+            operator=">=",
+            threshold=3,
+            notification_type="checkin_prompt",
+            message_template="test",
+        )
+        body = api.post.call_args[1]["json"]
+        assert body["entity_type"] == "checkin"
+
+    @pytest.mark.anyio
+    async def test_goal_entity_type_rejected(self, tools):
+        with pytest.raises(InputValidationError, match="entity_type"):
+            await tools["create_rule"](
+                name="Bad rule",
+                entity_type="goal",
+                metric="consecutive_skips",
+                operator=">=",
+                threshold=3,
+                notification_type="habit_nudge",
+                message_template="test",
+            )
+
+    @pytest.mark.parametrize("symbol", [">=", "<=", "=="])
+    @pytest.mark.anyio
+    async def test_all_operator_symbols_accepted(self, tools, api, symbol):
+        api.post.return_value = {"id": VALID_UUID}
+        await tools["create_rule"](
+            name=f"Rule {symbol}",
+            entity_type="habit",
+            metric="consecutive_skips",
+            operator=symbol,
+            threshold=3,
+            notification_type="habit_nudge",
+            message_template="test",
+        )
+        body = api.post.call_args[1]["json"]
+        assert body["operator"] == symbol
 
 
 # ---------------------------------------------------------------------------

--- a/mcp/tools/rules.py
+++ b/mcp/tools/rules.py
@@ -35,9 +35,10 @@ def register(mcp, api) -> None:
         meets a threshold, create a notification. Use this to set up
         automated nudges, alerts, and pattern-based interventions.
 
-        Available metrics: consecutive_skips, days_untouched,
-        non_responses, streak_length.
-        Operators: >= (gte), <= (lte), == (eq).
+        Entity types: habit, task, routine, checkin.
+        Metrics: consecutive_skips, days_untouched, non_responses,
+        streak_length.
+        Operators: must be sent as symbols — ">=", "<=", "==".
 
         Message templates support placeholders: {entity_name},
         {entity_type}, {metric_value}, {threshold}, {rule_name}.
@@ -139,6 +140,9 @@ def register(mcp, api) -> None:
         All fields are optional — only provided fields are changed. Use to
         tune thresholds, adjust cooldowns, enable/disable rules, or update
         message templates.
+
+        Entity types: habit, task, routine, checkin.
+        Operators: must be sent as symbols — ">=", "<=", "==".
         """
         validate_uuid(rule_id, "rule_id")
         validate_enum(entity_type, "entity_type", RULE_ENTITY_TYPES)

--- a/mcp/validation.py
+++ b/mcp/validation.py
@@ -51,9 +51,9 @@ NOTIFICATION_STATUSES = {"pending", "delivered", "responded", "expired"}
 DELIVERY_TYPES = {"notification"}
 SCHEDULED_BY_VALUES = {"system", "claude", "rule"}
 TARGET_ENTITY_TYPES = {"habit", "routine", "task", "checkin", "goal", "project"}
-RULE_ENTITY_TYPES = {"habit", "routine", "task", "goal", "project"}
+RULE_ENTITY_TYPES = {"habit", "task", "routine", "checkin"}
 RULE_METRICS = {"consecutive_skips", "days_untouched", "non_responses", "streak_length"}
-RULE_OPERATORS = {"gte", "lte", "eq"}
+RULE_OPERATORS = {">=", "<=", "=="}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Two validation set mismatches in `mcp/validation.py` were causing every `create_rule` / `update_rule` call to be rejected by the brain3 API. The MCP was sending Pydantic enum **names** (`gte`, `lte`, `eq`); Pydantic v2 validates str-enums by **value** (`">="`, `"<="`, `"=="`), so every call returned 422 before the body was applied. The sibling `RULE_ENTITY_TYPES` set also disagreed with the API enum — it accepted `goal` and `project` (rejected by the API) and excluded `checkin` (accepted by the API).

Both fixes ship together because they're the same category of bug in the same file. Single PR, one test pass.

## Changes

- `mcp/validation.py` — `RULE_OPERATORS` flipped from `{"gte", "lte", "eq"}` to `{">=", "<=", "=="}`. `RULE_ENTITY_TYPES` realigned to the API's `RuleEntityType` values: `{"habit", "task", "routine", "checkin"}`.
- `mcp/tools/rules.py` — `create_rule` and `update_rule` docstrings updated. Entity types are now listed explicitly (`habit, task, routine, checkin`). Operator guidance now says symbols only (`">="`, `"<="`, `"=="`) — the `(gte) / (lte) / (eq)` shorthand has been removed so the description doesn't imply names are valid input.
- `mcp/tests/test_rules.py` — all existing `operator="gte"` assertions converted to `operator=">="` (~12 locations). Added three new tests:
  - `test_checkin_entity_type_accepted` — confirms the newly allowed `checkin` type passes validation and is forwarded in the body.
  - `test_goal_entity_type_rejected` — confirms the now-removed `goal` type is rejected.
  - `test_all_operator_symbols_accepted` — parametrized over `">="`, `"<="`, `"=="` to lock in all three symbols.

## How to Verify

```bash
cd brain3-mcp/mcp
python -m pytest tests/test_rules.py -q   # 40 passed
python -m pytest tests/ -q                # 110 passed (full suite)
ruff check mcp/validation.py mcp/tools/rules.py mcp/tests/test_rules.py
```

Integration path (post-merge, after redeploy): `create_rule(operator=">=", entity_type="habit", ...)` returns 200 against the brain3 API instead of 422.

## Deviations

None. Implementation matches Stellan's Pass 1 recommendation (BRAIN artifact `77bb36c2-54e8-443e-ab67-a6daa747e0c0`) exactly — change the two validation sets, update the tool descriptions, swap the test values. The three additional tests (checkin accepted, goal rejected, symbol parametrization) are in-scope test coverage for the fix, not a scope expansion.

## Test Results

```
tests/test_rules.py  40 passed in 0.27s
tests/ (full suite) 110 passed in 1.39s
ruff: All checks passed!
```

## Acceptance Checklist

- [x] `RULE_OPERATORS` updated to `{">=", "<=", "=="}`
- [x] `RULE_ENTITY_TYPES` updated to `{"habit", "task", "routine", "checkin"}`
- [x] `create_rule` and `update_rule` tool descriptions reflect the corrected values
- [x] Existing test assertions updated to the symbol form
- [x] New coverage for `checkin` (now valid), `goal` (now invalid), all three operator symbols
- [x] Full MCP test suite passes
- [x] Ruff clean

Closes #54