### PR TITLE
fix: [2G-Bug-01] Add friction_score to create_habit and update_habit MCP tools

### DIFF
--- a/mcp/tests/test_habits.py
+++ b/mcp/tests/test_habits.py
@@ -1,0 +1,115 @@
+"""Tests for habit CRUD MCP tools."""
+
+import pytest
+from unittest.mock import AsyncMock
+
+from mcp.server.fastmcp import FastMCP
+from tools.habits import register
+from validation import InputValidationError
+
+
+VALID_UUID = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+
+
+@pytest.fixture()
+def api():
+    return AsyncMock()
+
+
+@pytest.fixture()
+def tools(api):
+    """Register habit tools and return a dict of tool functions."""
+    mcp = FastMCP("test")
+    register(mcp, api)
+    return {
+        name: tool.fn
+        for name, tool in mcp._tool_manager._tools.items()
+    }
+
+
+# ---------------------------------------------------------------------------
+# create_habit — friction_score
+# ---------------------------------------------------------------------------
+
+class TestCreateHabitFrictionScore:
+
+    @pytest.mark.anyio
+    async def test_friction_score_passed_through(self, tools, api):
+        api.post.return_value = {"id": VALID_UUID}
+        await tools["create_habit"](
+            title="Floss", frequency="daily", friction_score=3,
+        )
+        call_args = api.post.call_args
+        assert call_args[1]["json"]["friction_score"] == 3
+
+    @pytest.mark.anyio
+    async def test_friction_score_omitted_when_none(self, tools, api):
+        api.post.return_value = {"id": VALID_UUID}
+        await tools["create_habit"](title="Floss", frequency="daily")
+        call_args = api.post.call_args
+        assert "friction_score" not in call_args[1]["json"]
+
+    @pytest.mark.anyio
+    async def test_friction_score_boundary_low(self, tools, api):
+        api.post.return_value = {"id": VALID_UUID}
+        await tools["create_habit"](
+            title="Floss", frequency="daily", friction_score=1,
+        )
+        assert api.post.call_args[1]["json"]["friction_score"] == 1
+
+    @pytest.mark.anyio
+    async def test_friction_score_boundary_high(self, tools, api):
+        api.post.return_value = {"id": VALID_UUID}
+        await tools["create_habit"](
+            title="Floss", frequency="daily", friction_score=5,
+        )
+        assert api.post.call_args[1]["json"]["friction_score"] == 5
+
+    @pytest.mark.anyio
+    async def test_friction_score_below_range(self, tools, api):
+        with pytest.raises(InputValidationError, match="friction_score"):
+            await tools["create_habit"](
+                title="Floss", frequency="daily", friction_score=0,
+            )
+
+    @pytest.mark.anyio
+    async def test_friction_score_above_range(self, tools, api):
+        with pytest.raises(InputValidationError, match="friction_score"):
+            await tools["create_habit"](
+                title="Floss", frequency="daily", friction_score=6,
+            )
+
+
+# ---------------------------------------------------------------------------
+# update_habit — friction_score
+# ---------------------------------------------------------------------------
+
+class TestUpdateHabitFrictionScore:
+
+    @pytest.mark.anyio
+    async def test_friction_score_passed_through(self, tools, api):
+        api.patch.return_value = {"id": VALID_UUID}
+        await tools["update_habit"](habit_id=VALID_UUID, friction_score=4)
+        call_args = api.patch.call_args
+        assert call_args[1]["json"]["friction_score"] == 4
+
+    @pytest.mark.anyio
+    async def test_friction_score_omitted_when_none(self, tools, api):
+        api.patch.return_value = {"id": VALID_UUID}
+        await tools["update_habit"](habit_id=VALID_UUID, title="New title")
+        call_args = api.patch.call_args
+        assert "friction_score" not in call_args[1]["json"]
+
+    @pytest.mark.anyio
+    async def test_friction_score_below_range(self, tools, api):
+        with pytest.raises(InputValidationError, match="friction_score"):
+            await tools["update_habit"](
+                habit_id=VALID_UUID, friction_score=0,
+            )
+
+    @pytest.mark.anyio
+    async def test_friction_score_above_range(self, tools, api):
+        with pytest.raises(InputValidationError, match="friction_score"):
+            await tools["update_habit"](
+                habit_id=VALID_UUID, friction_score=10,
+            )

--- a/mcp/tools/habits.py
+++ b/mcp/tools/habits.py
@@ -3,6 +3,7 @@
 from validation import (
     InputValidationError,
     validate_enum,
+    validate_range,
     validate_uuid,
     validate_required_str,
     HABIT_STATUSES,
@@ -29,6 +30,7 @@ def register(mcp, api) -> None:
         graduation_window: int | None = None,
         graduation_target: float | None = None,
         graduation_threshold: int | None = None,
+        friction_score: int | None = None,
     ) -> dict:
         """Create a new habit, standalone or under a routine.
 
@@ -38,6 +40,10 @@ def register(mcp, api) -> None:
 
         Scaffolding starts at "tracking" — the user just logs completions.
         Later stages add accountability and graduation criteria.
+
+        friction_score (1–5) captures how hard this habit feels to the user
+        and drives graduation defaults: higher friction = longer window and
+        more lenient targets.
         """
         validate_required_str(title, "title")
         validate_uuid(routine_id, "routine_id")
@@ -45,6 +51,7 @@ def register(mcp, api) -> None:
         validate_enum(frequency, "frequency", HABIT_FREQUENCIES)
         validate_enum(notification_frequency, "notification_frequency", NOTIFICATION_FREQUENCIES)
         validate_enum(scaffolding_status, "scaffolding_status", SCAFFOLDING_STATUSES)
+        validate_range(friction_score, "friction_score", 1, 5)
         if routine_id is None and frequency is None:
             raise InputValidationError(
                 "Missing required parameter: frequency. "
@@ -67,6 +74,7 @@ def register(mcp, api) -> None:
             "graduation_window": graduation_window,
             "graduation_target": graduation_target,
             "graduation_threshold": graduation_threshold,
+            "friction_score": friction_score,
         })
         return await api.post("/api/habits/", json=body)
 
@@ -119,12 +127,17 @@ def register(mcp, api) -> None:
         graduation_window: int | None = None,
         graduation_target: float | None = None,
         graduation_threshold: int | None = None,
+        friction_score: int | None = None,
     ) -> dict:
         """Update a habit's details.
 
         Only provided fields are changed. Use this to advance scaffolding
         status, pause/resume a habit, adjust graduation criteria, or change
         notification frequency.
+
+        friction_score (1–5) captures how hard this habit feels to the user
+        and drives graduation defaults: higher friction = longer window and
+        more lenient targets.
         """
         validate_uuid(habit_id, "habit_id")
         validate_uuid(routine_id, "routine_id")
@@ -132,6 +145,7 @@ def register(mcp, api) -> None:
         validate_enum(frequency, "frequency", HABIT_FREQUENCIES)
         validate_enum(notification_frequency, "notification_frequency", NOTIFICATION_FREQUENCIES)
         validate_enum(scaffolding_status, "scaffolding_status", SCAFFOLDING_STATUSES)
+        validate_range(friction_score, "friction_score", 1, 5)
         if graduation_target is not None and not (0.0 <= graduation_target <= 1.0):
             raise InputValidationError(
                 f"Invalid graduation_target: {graduation_target}. "
@@ -149,6 +163,7 @@ def register(mcp, api) -> None:
             "graduation_window": graduation_window,
             "graduation_target": graduation_target,
             "graduation_threshold": graduation_threshold,
+            "friction_score": friction_score,
         })
         return await api.patch(f"/api/habits/{habit_id}", json=body)
 


### PR DESCRIPTION
## Summary

`friction_score` is a 1–5 signal on habits that drives graduation defaults — higher friction extends the evaluation window and loosens target rates. The brain3 API has full end-to-end support (model, `HabitCreate` / `HabitUpdate` schemas, validators, router), but the MCP tools in `mcp/tools/habits.py` were never updated when Stream G landed. The [2G-01] spec assumed MCP would auto-expose new schema fields — MCP tools are hand-defined, so each parameter has to be added explicitly.

Result before this PR: Claude cannot set or change `friction_score` on a habit through `create_habit` or `update_habit`. The field stays NULL and the API picks its own defaults regardless of how hard the user says the habit feels.

## Changes

- `mcp/tools/habits.py`
  - `create_habit` and `update_habit` gain `friction_score: int | None = None` parameters.
  - `validate_range(friction_score, "friction_score", 1, 5)` runs before the HTTP request, matching the API's `CheckConstraint` (the pre-existing `validate_range` helper already targets the 1–5 default range).
  - `friction_score` added to the body construction in both tools, so it passes through the existing `strip_nones()` idiom like every other optional field.
  - Both tool docstrings gain a short paragraph documenting the 1–5 scale and the graduation-default behavior, so Claude knows when to offer it.
  - `validate_range` imported from `validation`.
- `mcp/tests/test_habits.py` *(new file — no prior habit tool tests existed)*
  - `TestCreateHabitFrictionScore` — 6 tests: passthrough of an integer, omission when None, boundary values 1 and 5 accepted, out-of-range 0 and 6 rejected.
  - `TestUpdateHabitFrictionScore` — 4 tests: passthrough, omission, below-range (0) and above-range (10) rejection.
  - Scope intentionally narrow — covers the new parameter, not the whole habit CRUD surface (that's a separate coverage gap, out of scope for this issue).

## How to Verify

```bash
cd brain3-mcp/mcp
python -m pytest tests/test_habits.py -q   # 10 passed
python -m pytest tests/ -q                 # 120 passed (full suite)
ruff check mcp/tools/habits.py mcp/tests/test_habits.py
```

Integration path (post-merge, after redeploy): `create_habit(title="Floss", frequency="daily", friction_score=4)` persists `friction_score=4` on the habit, and subsequent graduation evaluation uses friction-adjusted defaults.

## Deviations

None. Implementation matches Stellan's Pass 1 recommendation (BRAIN artifact `77bb36c2-54e8-443e-ab67-a6daa747e0c0`, §ST-01) exactly — add the parameter, add the range validation, include in the body, update the descriptions. Stellan's brief flagged that `re_scaffold_count` and `last_frequency_changed_at` are also undocumented in the habit tool descriptions (BF-01); that's covered by issue #56 and is **not** bundled here.

## Test Results

```
tests/test_habits.py    10 passed in 0.09s
tests/ (full suite)    120 passed in 1.41s
ruff: All checks passed!
```

## Acceptance Checklist

- [x] `friction_score: int | None = None` added to both `create_habit` and `update_habit` signatures
- [x] Range validation (1–5) via the existing `validate_range` helper
- [x] Parameter included in request body construction via `strip_nones()`
- [x] Both tool descriptions document `friction_score`
- [x] Tests cover passthrough, omission, boundaries, and out-of-range rejection on both tools
- [x] Full MCP test suite passes
- [x] Ruff clean

Closes #55