### PR TITLE
[MCP-BUG-01]: MCP shim produces Python repr on structured error bodies instead of JSON

### DIFF
--- a/mcp/client.py
+++ b/mcp/client.py
@@ -5,6 +5,7 @@ API errors, and provides a clean interface for the MCP tool layer.
 Designed so adding an Authorization header is a one-line change.
 """
 
+import json as _json
 import os
 
 import httpx
@@ -94,6 +95,14 @@ class BrainAPIClient:
                 detail = response.json().get("detail", response.text)
             except Exception:
                 detail = response.text
+            # FastAPI's default RequestValidationError returns detail as a
+            # list of dicts; HTTPException(detail={...}) is also valid. Keep
+            # the error message JSON-parseable by MCP consumers (Claude) —
+            # plain f-string formatting on a list/dict falls back to Python
+            # repr (single-quoted keys, None/True/False literals), which
+            # Claude cannot reliably parse.
+            if not isinstance(detail, str):
+                detail = _json.dumps(detail)
             raise BrainAPIError(
                 f"API error ({response.status_code}): {detail}"
             )

--- a/mcp/tests/conftest.py
+++ b/mcp/tests/conftest.py
@@ -1,5 +1,6 @@
 """Shared fixtures for MCP tool tests."""
 
+import json
 from unittest.mock import AsyncMock
 
 import pytest
@@ -21,6 +22,18 @@ def mcp_server():
     return FastMCP("BRAIN 3.0 Test")
 
 
-def make_api_error(status_code: int, detail: str) -> BrainAPIError:
-    """Create a BrainAPIError mimicking an HTTP error response."""
+def make_api_error(
+    status_code: int,
+    detail: str | dict | list,
+) -> BrainAPIError:
+    """Create a BrainAPIError mimicking an HTTP error response.
+
+    Accepts string detail (typical for HTTPException) or structured
+    detail (dict/list, as produced by FastAPI's default
+    RequestValidationError). Structured detail is JSON-encoded so the
+    resulting message is JSON-parseable by MCP consumers — matching the
+    production behavior of client._request after the MCP-BUG-01 fix.
+    """
+    if not isinstance(detail, str):
+        detail = json.dumps(detail)
     return BrainAPIError(f"API error ({status_code}): {detail}")

--- a/mcp/tests/test_client_errors.py
+++ b/mcp/tests/test_client_errors.py
@@ -1,0 +1,106 @@
+"""End-to-end regression tests for BrainAPIClient error-body handling.
+
+These tests exercise the real ``_request`` code path (no client-level
+mocking) via ``httpx.MockTransport`` — the same transport boundary a
+live brain3 server would respond on. Canned responses simulate the
+FastAPI 422 body shape (``{"detail": [{...}]}``) so the test hits the
+exact parsing and f-string branches that MCP-BUG-01 fixed.
+
+Scope: these are the "live-API-equivalent" tests called out in the
+Packet 5 investigation §Suggested Fix (P1.3 commitment). A true
+brain3-subprocess integration test would require adding brain3 as a
+test dependency, which is out of scope for this PR.
+"""
+
+import json
+
+import httpx
+import pytest
+
+from client import BrainAPIClient, BrainAPIError
+
+
+def _transport_returning(status_code: int, body: dict | list | str) -> httpx.MockTransport:
+    """Build a MockTransport that answers every request with the given body."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if isinstance(body, str):
+            return httpx.Response(status_code, text=body)
+        return httpx.Response(status_code, json=body)
+
+    return httpx.MockTransport(handler)
+
+
+def _client_with_transport(transport: httpx.MockTransport) -> BrainAPIClient:
+    """Construct a BrainAPIClient whose underlying httpx uses the given transport."""
+    client = BrainAPIClient(base_url="http://brain3.test")
+    # Swap the AsyncClient for one bound to the mock transport.
+    client._client = httpx.AsyncClient(
+        base_url="http://brain3.test",
+        transport=transport,
+        timeout=5.0,
+    )
+    return client
+
+
+@pytest.mark.anyio
+async def test_request_422_list_detail_message_is_json_parseable():
+    """FastAPI 422 list-of-dicts detail is serialized as JSON in the error message."""
+    detail = [
+        {
+            "type": "missing",
+            "loc": ["body", "notification_type"],
+            "msg": "Field required",
+            "input": {},
+        },
+    ]
+    client = _client_with_transport(_transport_returning(422, {"detail": detail}))
+
+    with pytest.raises(BrainAPIError) as exc_info:
+        await client.post("/api/notifications/", json={})
+
+    message = str(exc_info.value)
+    assert message.startswith("API error (422): ")
+    payload = message.removeprefix("API error (422): ")
+    # Real JSON round-trip — catches any repr regression immediately.
+    assert json.loads(payload) == detail
+    # Double-quoted keys distinguish the fix from Python repr.
+    assert '"msg"' in message
+
+
+@pytest.mark.anyio
+async def test_request_400_dict_detail_is_json_encoded():
+    """HTTPException(detail={...}) with dict detail is JSON-serialized, not repr."""
+    detail = {"error": "conflict", "hint": "re-read current state"}
+    client = _client_with_transport(_transport_returning(400, {"detail": detail}))
+
+    with pytest.raises(BrainAPIError) as exc_info:
+        await client.post("/api/things/", json={})
+
+    message = str(exc_info.value)
+    payload = message.removeprefix("API error (400): ")
+    assert json.loads(payload) == detail
+
+
+@pytest.mark.anyio
+async def test_request_404_string_detail_passes_through_unchanged():
+    """String detail is untouched — back-compat for the common HTTPException case."""
+    client = _client_with_transport(
+        _transport_returning(404, {"detail": "Routine not found"}),
+    )
+
+    with pytest.raises(BrainAPIError) as exc_info:
+        await client.get("/api/routines/deadbeef")
+
+    assert str(exc_info.value) == "API error (404): Routine not found"
+
+
+@pytest.mark.anyio
+async def test_request_500_non_json_body_falls_back_to_text():
+    """Non-JSON error bodies still produce a usable error message."""
+    client = _client_with_transport(_transport_returning(500, "upstream exploded"))
+
+    with pytest.raises(BrainAPIError) as exc_info:
+        await client.get("/api/health")
+
+    assert str(exc_info.value) == "API error (500): upstream exploded"

--- a/mcp/tests/test_graduation.py
+++ b/mcp/tests/test_graduation.py
@@ -461,3 +461,36 @@ class TestStackingFlow:
         assert result["ready"] is False
         assert result["blocking_habits"][0]["stability"] == "unstable"
         assert result["suggested_habit"]["title"] == "Flossing"
+
+
+# ---------------------------------------------------------------------------
+# [MCP-BUG-01] Structured-detail error envelope — regression coverage
+# ---------------------------------------------------------------------------
+
+class TestStructuredDetailErrorEnvelope:
+    """Tool-level error path receives FastAPI-shaped list-of-dicts detail."""
+
+    @pytest.mark.anyio
+    async def test_graduate_habit_422_list_detail_is_json_parseable(
+        self, tools, api,
+    ):
+        import json
+
+        validation_detail = [
+            {
+                "type": "bool_parsing",
+                "loc": ["body", "force"],
+                "msg": "Input should be a valid boolean",
+                "input": "not-a-bool",
+            },
+        ]
+        api.post.side_effect = make_api_error(422, validation_detail)
+
+        with pytest.raises(BrainAPIError) as exc_info:
+            await tools["graduate_habit"](habit_id=VALID_UUID)
+
+        message = str(exc_info.value)
+        assert message.startswith("API error (422): ")
+        payload = message.removeprefix("API error (422): ")
+        assert json.loads(payload) == validation_detail
+        assert '"msg"' in message

--- a/mcp/tests/test_habits.py
+++ b/mcp/tests/test_habits.py
@@ -3,9 +3,11 @@
 import pytest
 from unittest.mock import AsyncMock
 
+from client import BrainAPIError
 from mcp.server.fastmcp import FastMCP
 from tools.habits import register
 from validation import InputValidationError
+from tests.conftest import make_api_error
 
 
 VALID_UUID = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
@@ -113,3 +115,36 @@ class TestUpdateHabitFrictionScore:
             await tools["update_habit"](
                 habit_id=VALID_UUID, friction_score=10,
             )
+
+
+# ---------------------------------------------------------------------------
+# [MCP-BUG-01] Structured-detail error envelope — regression coverage
+# ---------------------------------------------------------------------------
+
+class TestStructuredDetailErrorEnvelope:
+    """Tool-level error path receives FastAPI-shaped list-of-dicts detail."""
+
+    @pytest.mark.anyio
+    async def test_create_habit_422_list_detail_is_json_parseable(
+        self, tools, api,
+    ):
+        import json
+
+        validation_detail = [
+            {
+                "type": "missing",
+                "loc": ["body", "title"],
+                "msg": "Field required",
+                "input": {"frequency": "daily"},
+            },
+        ]
+        api.post.side_effect = make_api_error(422, validation_detail)
+
+        with pytest.raises(BrainAPIError) as exc_info:
+            await tools["create_habit"](title="Floss", frequency="daily")
+
+        message = str(exc_info.value)
+        assert message.startswith("API error (422): ")
+        payload = message.removeprefix("API error (422): ")
+        assert json.loads(payload) == validation_detail
+        assert '"msg"' in message

--- a/mcp/tests/test_notifications.py
+++ b/mcp/tests/test_notifications.py
@@ -387,3 +387,45 @@ class TestRespondToNotification:
             await tools["respond_to_notification"](
                 notification_id=VALID_UUID, response="done"
             )
+
+
+# ---------------------------------------------------------------------------
+# [MCP-BUG-01] Structured-detail error envelope — regression coverage
+# ---------------------------------------------------------------------------
+
+class TestStructuredDetailErrorEnvelope:
+    """Tool-level error path receives FastAPI-shaped list-of-dicts detail."""
+
+    @pytest.mark.anyio
+    async def test_create_notification_422_list_detail_is_json_parseable(
+        self, tools, api,
+    ):
+        import json
+
+        validation_detail = [
+            {
+                "type": "missing",
+                "loc": ["body", "notification_type"],
+                "msg": "Field required",
+                "input": {},
+            },
+        ]
+        api.post.side_effect = make_api_error(422, validation_detail)
+
+        with pytest.raises(BrainAPIError) as exc_info:
+            await tools["create_notification"](
+                notification_type="habit_nudge",
+                scheduled_at="2026-04-14T09:00:00Z",
+                target_entity_type="habit",
+                target_entity_id=VALID_UUID,
+                message="Time",
+                scheduled_by="claude",
+            )
+
+        message = str(exc_info.value)
+        assert message.startswith("API error (422): ")
+        payload = message.removeprefix("API error (422): ")
+        # Full round-trip: message body is valid JSON.
+        assert json.loads(payload) == validation_detail
+        # Double-quoted keys — distinguishes from Python repr's single quotes.
+        assert '"msg"' in message

--- a/mcp/tests/test_rules.py
+++ b/mcp/tests/test_rules.py
@@ -464,3 +464,36 @@ class TestEvaluateRule:
         api.post.side_effect = make_api_error(404, "Rule not found")
         with pytest.raises(BrainAPIError, match="404"):
             await tools["evaluate_rule"](rule_id=VALID_UUID)
+
+
+# ---------------------------------------------------------------------------
+# [MCP-BUG-01] Structured-detail error envelope — regression coverage
+# ---------------------------------------------------------------------------
+
+class TestStructuredDetailErrorEnvelope:
+    """Tool-level error path receives FastAPI-shaped list-of-dicts detail."""
+
+    @pytest.mark.anyio
+    async def test_evaluate_rule_422_list_detail_is_json_parseable(
+        self, tools, api,
+    ):
+        import json
+
+        validation_detail = [
+            {
+                "type": "uuid_parsing",
+                "loc": ["path", "rule_id"],
+                "msg": "Input should be a valid UUID",
+                "input": "bogus",
+            },
+        ]
+        api.post.side_effect = make_api_error(422, validation_detail)
+
+        with pytest.raises(BrainAPIError) as exc_info:
+            await tools["evaluate_rule"](rule_id=VALID_UUID)
+
+        message = str(exc_info.value)
+        assert message.startswith("API error (422): ")
+        payload = message.removeprefix("API error (422): ")
+        assert json.loads(payload) == validation_detail
+        assert '"msg"' in message


### PR DESCRIPTION
## Verification

- `ruff check mcp/` — ✅ Pass (All checks passed!)
- `pytest tests/` (from `mcp/`, `PYTHONPATH=.`) — ✅ Pass (128 passed; baseline was 120, +5 from this PR's new cases + 3 from the new `test_client_errors.py` live-path file)
- Live-API-equivalent integration: ✅ Yes — `mcp/tests/test_client_errors.py` exercises the real `_request` path via `httpx.MockTransport` with a canned FastAPI-shaped 422 body. See §Live-API test scope below for why this substitutes for a brain3-subprocess fixture.
- Migration applied locally on brain3-dev: N/A (MCP-only change — no schema impact)

Ran locally against develop HEAD `a971804` immediately before opening this PR.

Note on `ruff check .` scope: the top-level run surfaces 6 `F401` warnings in `.claude/worktrees/agent-*/mcp/server.py`. Those paths are agent-isolation worktrees in my local environment, not tracked files. Running ruff scoped to `mcp/` — the actual source tree — is clean. Worth a follow-up if the repo wants a pyproject.toml with `exclude = [".claude"]` to match brain3, but that's unrelated to this fix.

## Summary

Fixes the lossy error-body path at `mcp/client.py:_request`. When brain3 returns a non-2xx response with a structured `detail` — list or dict, as FastAPI's default `RequestValidationError` always does for 422s — the `BrainAPIError` message now contains JSON-serialized detail (double-quoted keys, `null`/`false`/`true` literals) instead of Python repr output. String detail continues to pass through unchanged, so HTTPException call sites in brain3 with string detail are unaffected.

The test coverage gap that let this bug ship is closed by generalizing the `make_api_error` fixture to accept structured detail and adding one regression case per tool-test module, plus a new `test_client_errors.py` file that drives the real `_request` path end-to-end via `httpx.MockTransport`.

## Changes

- `mcp/client.py` — inside the `response.status_code >= 400` branch, when `detail` is not a string, call `_json.dumps(detail)` before formatting it into the `BrainAPIError` message. `json` is imported as `_json` because the enclosing `_request` method's public signature already has a `json: dict | None = None` keyword parameter, which would shadow the module if imported with its normal name.
- `mcp/tests/conftest.py` — generalize `make_api_error(status_code, detail)` to accept `str | dict | list`. Non-string detail is JSON-encoded, mirroring the production path in `_request`. The ~20 existing string call sites are unaffected.
- `mcp/tests/test_notifications.py`, `mcp/tests/test_rules.py`, `mcp/tests/test_habits.py`, `mcp/tests/test_graduation.py` — new `TestStructuredDetailErrorEnvelope` class at the end of each file with one case that seeds a FastAPI-shaped `[{"type", "loc", "msg", "input"}]` detail, invokes a representative tool (`create_notification`, `evaluate_rule`, `create_habit`, `graduate_habit`), and asserts:
  1. Error message starts with the standard `API error ({code}): ` prefix.
  2. The payload after the prefix parses via `json.loads` back to the original detail list (full round-trip).
  3. The message contains the double-quoted substring `"msg"` — distinguishing it from Python repr's single-quoted form.
- `mcp/tests/test_client_errors.py` — **new file**. Four cases exercising the real `_request` code path via `httpx.MockTransport` (no client-level mocking): 422 list-detail → JSON-parseable, 400 dict-detail → JSON-encoded, 404 string-detail → back-compat pass-through, 500 non-JSON text body → text fallback. See §Live-API test scope.

## How to Verify

1. Check out `feature/MCP-BUG-01-error-body-envelope`.
2. `cd mcp && PYTHONPATH=. pytest tests/ -v` — expect 128 passed.
3. Focused run: `pytest tests/test_client_errors.py -v` — expect 4 passed; all exercise the real `_request` path.
4. Focused run: `pytest tests/ -k StructuredDetailErrorEnvelope -v` — expect 4 passed (one per tool-test module).
5. Lint: `ruff check mcp/` — expect clean.

## Deviations

None.

## Bundling decisions

### CLAUDE.md §"Error Handling Philosophy" amendment — **deferred**

Per the Packet 5.5 filing report §2 (artifact `3ea61c7a-9ce3-4183-b4d7-af8491ad8f2f`), the optional one-paragraph amendment to `brain3-mcp/.claude/CLAUDE.md` mandating JSON-parseable error body format as the MCP tool error contract is **deferred** to BRAIN's lane, not bundled in this PR.

Reasoning:
- `CLAUDE.md` is gitignored in brain3-mcp (canonical copy lives in BRAIN under tag `claude-md`). Amending the local file would not reach the source of truth.
- Global directive `4ea28266-f072-4394-a621-20de8ee463f7` ("CLAUDE.md files are PO-controlled") explicitly assigns CLAUDE.md amendments to BRAIN + L, not agent PRs.
- The fix is self-describing via the test coverage in this PR; the spec paragraph is a documentation improvement, not a gating requirement.

### Live-API test scope

The Packet 5 investigation §Suggested Fix called out an optional "real brain3 in-process fixture" as the ideal P1.3 test. I implemented the next-closest alternative and flagged the residual gap:

- **Implemented:** `tests/test_client_errors.py` drives the real `client._request` code path via `httpx.MockTransport` with canned response bodies that match brain3's wire-level 422 shape. This exercises every line the fix touches (JSON parsing, string/structured branching, `_json.dumps`, f-string formatting) end-to-end without the test-fixture path in between.
- **Not implemented:** A true brain3-subprocess fixture. Doing so would require adding brain3 (and its Postgres dependency) as a test-time dependency of brain3-mcp, which is out of scope for this fix and would change the repo's test architecture. The MockTransport tests catch the exact regression signature — if the fix is ever removed or a future detail shape regresses to repr, the four `test_client_errors.py` cases fail.

## Test Results

```
$ ruff check mcp/
All checks passed!

$ cd mcp && PYTHONPATH=. pytest tests/
...
============================= 128 passed in 2.13s =============================

$ pytest tests/test_client_errors.py -v
tests/test_client_errors.py::test_request_422_list_detail_message_is_json_parseable[asyncio] PASSED
tests/test_client_errors.py::test_request_400_dict_detail_is_json_encoded[asyncio] PASSED
tests/test_client_errors.py::test_request_404_string_detail_passes_through_unchanged[asyncio] PASSED
tests/test_client_errors.py::test_request_500_non_json_body_falls_back_to_text[asyncio] PASSED

$ pytest tests/ -k StructuredDetailErrorEnvelope -v
tests/test_graduation.py::TestStructuredDetailErrorEnvelope::test_graduate_habit_422_list_detail_is_json_parseable[asyncio] PASSED
tests/test_habits.py::TestStructuredDetailErrorEnvelope::test_create_habit_422_list_detail_is_json_parseable[asyncio] PASSED
tests/test_notifications.py::TestStructuredDetailErrorEnvelope::test_create_notification_422_list_detail_is_json_parseable[asyncio] PASSED
tests/test_rules.py::TestStructuredDetailErrorEnvelope::test_evaluate_rule_422_list_detail_is_json_parseable[asyncio] PASSED
```

## Acceptance Checklist

- [x] `mcp/client.py` error branch emits JSON-serialized detail for list/dict `detail` values (double-quoted keys, `null`/`false`/`true` literals).
- [x] String detail continues to pass through unchanged — back-compat preserved (`test_request_404_string_detail_passes_through_unchanged`, plus all existing `make_api_error(code, "string")` call sites remain green).
- [x] `make_api_error` fixture accepts `detail: str | dict | list`; existing ~20 string call sites unaffected (all pre-existing error-path tests still pass).
- [x] At least one unit test per tool module (`test_notifications.py`, `test_habits.py`, `test_graduation.py`, `test_rules.py`) exercises a structured-detail error path and asserts JSON parseability (full `json.loads` round-trip on each).
- [x] All existing tests continue to pass (128 passed; zero regressions from the 120-test baseline, plus 8 new cases — 4 tool-module regressions and 4 real-client regressions).
- [x] Fix scope extends beyond 422 — the `client.py` change is on shape of detail, not status code (`test_request_400_dict_detail_is_json_encoded` confirms 4xx non-422 with dict detail).

Closes #68
