### PR TITLE
[2A-Bug-01]: Update list_habits tool annotation and test mocks to items+count envelope

### DIFF
--- a/mcp/tests/test_habits.py
+++ b/mcp/tests/test_habits.py
@@ -118,6 +118,60 @@ class TestUpdateHabitFrictionScore:
 
 
 # ---------------------------------------------------------------------------
+# list_habits — envelope response shape
+# ---------------------------------------------------------------------------
+
+class TestListHabits:
+    """list_habits returns the {items, count} envelope from /api/habits/."""
+
+    @pytest.mark.anyio
+    async def test_no_filters_empty_envelope(self, tools, api):
+        api.get.return_value = {"items": [], "count": 0}
+        result = await tools["list_habits"]()
+        assert result == {"items": [], "count": 0}
+        assert result["items"] == []
+        assert result["count"] == 0
+        api.get.assert_called_once_with("/api/habits/", params=None)
+
+    @pytest.mark.anyio
+    async def test_envelope_items_passed_through(self, tools, api):
+        api.get.return_value = {
+            "items": [
+                {"id": VALID_UUID, "title": "Floss"},
+                {"id": "b2c3d4e5-f6a7-8901-bcde-f12345678901", "title": "Walk"},
+            ],
+            "count": 2,
+        }
+        result = await tools["list_habits"]()
+        assert result["count"] == 2
+        assert len(result["items"]) == 2
+        assert result["items"][0]["title"] == "Floss"
+
+    @pytest.mark.anyio
+    async def test_all_filters_forwarded(self, tools, api):
+        api.get.return_value = {"items": [], "count": 0}
+        await tools["list_habits"](
+            routine_id=VALID_UUID,
+            status="active",
+            scaffolding_status="tracking",
+        )
+        call_params = api.get.call_args[1]["params"]
+        assert call_params["routine_id"] == VALID_UUID
+        assert call_params["status"] == "active"
+        assert call_params["scaffolding_status"] == "tracking"
+
+    @pytest.mark.anyio
+    async def test_invalid_status_filter(self, tools):
+        with pytest.raises(InputValidationError, match="status"):
+            await tools["list_habits"](status="bogus")
+
+    @pytest.mark.anyio
+    async def test_invalid_scaffolding_status_filter(self, tools):
+        with pytest.raises(InputValidationError, match="scaffolding_status"):
+            await tools["list_habits"](scaffolding_status="bogus")
+
+
+# ---------------------------------------------------------------------------
 # [MCP-BUG-01] Structured-detail error envelope — regression coverage
 # ---------------------------------------------------------------------------
 

--- a/mcp/tools/habits.py
+++ b/mcp/tools/habits.py
@@ -94,12 +94,15 @@ def register(mcp, api) -> None:
         routine_id: str | None = None,
         status: str | None = None,
         scaffolding_status: str | None = None,
-    ) -> list:
+    ) -> dict:
         """List habits with optional filters.
 
         Use this to see what habits the user is building, check on scaffolding
         progress, or find habits linked to a specific routine. All filters
         combine with AND logic.
+
+        Returns a `HabitListResponse` envelope: ``{"items": [...], "count": N}``.
+        ``items`` is the habit list; ``count`` is the total matching the filters.
         """
         validate_uuid(routine_id, "routine_id")
         validate_enum(status, "status", HABIT_STATUSES)


### PR DESCRIPTION
## Verification

- `ruff check mcp/` — ✅ Pass (All checks passed!)
- `pytest tests/` (from `mcp/`, `PYTHONPATH=.`) — ✅ Pass (133 passed; baseline 128, +5 from new `TestListHabits`)
- Migration applied locally on brain3-dev: N/A (MCP-only annotation/test change, no schema impact)
- Postgres-backed test confirmed: N/A (mock-based shim test)
- Gating brain3 PR merged on develop: ✅ Yes — `bc83e6c` `feat(habits): wrap list endpoint in HabitListResponse envelope (#174)` (merge `b47d828`)

Ran locally against brain3-mcp develop HEAD `24485b0` immediately before opening this PR.

## Summary

Mirrors the brain3 #174 envelope through the MCP shim. `list_habits` now returns the `HabitListResponse` envelope (`{items, count}`) end-to-end instead of the bare list it inherited from the pre-#174 API contract. This closes the contract mismatch surfaced in the Packet 1.5 Phase 2 envelope audit (BRAIN artifact `fbefbeef-30a3-48bb-9a07-97224d14a9fb`, row A.2).

The fix is the same shape as Packet 1's universal-defect resolution: change the return annotation so FastMCP's structured-output schema generation reflects the runtime dict, and document the envelope keys in the tool description so Claude parses the response correctly on first call. No new behavior — the MCP layer was always going to receive whatever the API returned; this aligns the shim's annotation, docstring, and test mocks with the API's now-envelope-shaped reality.

## Changes

- `mcp/tools/habits.py` — `list_habits` return annotation changed from `-> list` to `-> dict`. Docstring extended with one paragraph documenting the `{"items": [...], "count": N}` envelope shape so Claude has schema-level guidance for the new contract. No behavior change in the body — the call already passes the API response through verbatim, which now happens to be a dict.
- `mcp/tests/test_habits.py` — new `TestListHabits` class with five cases:
  1. `test_no_filters_empty_envelope` — bare call returns `{"items": [], "count": 0}`, asserts the envelope round-trips and the API is hit with `params=None`.
  2. `test_envelope_items_passed_through` — populated envelope returns through the shim with both `items` length and `count` preserved.
  3. `test_all_filters_forwarded` — `routine_id`, `status`, `scaffolding_status` all reach the underlying `api.get` call's params dict.
  4. `test_invalid_status_filter` — `status="bogus"` raises `InputValidationError` before any HTTP call.
  5. `test_invalid_scaffolding_status_filter` — same for `scaffolding_status="bogus"`.

  Mocks throughout use the new envelope shape (`{"items": ..., "count": ...}`), avoiding the test-mock-vs-reality drift documented in Packet 1 §2.10.

## How to Verify

1. Check out `feature/A-9-env-habits-list-envelope`.
2. `cd mcp && PYTHONPATH=. pytest tests/ -v` — expect 133 passed.
3. Focused run: `pytest tests/test_habits.py -v -k TestListHabits` — expect 5 passed.
4. Lint: `ruff check mcp/` — expect clean.

## Deviations

None. The Suggested Fix in #61 references updating existing `list_habits` test mocks; the file did not actually have any (only `TestCreateHabitFrictionScore`, `TestUpdateHabitFrictionScore`, and `TestStructuredDetailErrorEnvelope`). New `TestListHabits` class added with envelope-shape mocks from the start, matching the issue's intent and the recommended N≥2 items case from Packet 1 §10 follow-up #3.

Out of scope (separate Wave 3 tickets): `introduced_at` → `accountable_since` rename (#67), `effective_graduation_params` description update on `get_habit` (#66). Not touched in this PR.

## Acceptance Checklist

- [x] `list_habits` return annotation is `-> dict`
- [x] Tool description mentions the `{items, count}` envelope keys
- [x] Test mocks for `list_habits` use the envelope shape, not bare lists
- [x] At least one test asserts `result["items"]` / `result["count"]` access patterns
- [x] Filter validation tests preserved; new tests added for filter forwarding
- [x] Full test suite passes locally
- [x] `ruff check mcp/` clean

Closes #61