### PR TITLE
[2A-Bug-02]: Update list_routines tool annotation and test mocks to items+count envelope

### DIFF
--- a/mcp/tests/test_routines.py
+++ b/mcp/tests/test_routines.py
@@ -1,0 +1,84 @@
+"""Tests for routine MCP tools."""
+
+import pytest
+from unittest.mock import AsyncMock
+
+from mcp.server.fastmcp import FastMCP
+from tools.routines import register
+from validation import InputValidationError
+
+
+VALID_UUID = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+VALID_UUID_2 = "b2c3d4e5-f6a7-8901-bcde-f12345678901"
+
+
+@pytest.fixture()
+def api():
+    return AsyncMock()
+
+
+@pytest.fixture()
+def tools(api):
+    """Register routine tools and return a dict of tool functions."""
+    mcp = FastMCP("test")
+    register(mcp, api)
+    return {
+        name: tool.fn
+        for name, tool in mcp._tool_manager._tools.items()
+    }
+
+
+# ---------------------------------------------------------------------------
+# list_routines — envelope response shape
+# ---------------------------------------------------------------------------
+
+class TestListRoutines:
+    """list_routines returns the {items, count} envelope from /api/routines/."""
+
+    @pytest.mark.anyio
+    async def test_no_filters_empty_envelope(self, tools, api):
+        api.get.return_value = {"items": [], "count": 0}
+        result = await tools["list_routines"]()
+        assert result == {"items": [], "count": 0}
+        assert result["items"] == []
+        assert result["count"] == 0
+        api.get.assert_called_once_with("/api/routines/", params=None)
+
+    @pytest.mark.anyio
+    async def test_envelope_items_passed_through(self, tools, api):
+        api.get.return_value = {
+            "items": [
+                {"id": VALID_UUID, "title": "Morning meditation"},
+                {"id": VALID_UUID_2, "title": "Evening journal"},
+            ],
+            "count": 2,
+        }
+        result = await tools["list_routines"]()
+        assert result["count"] == 2
+        assert len(result["items"]) == 2
+        assert result["items"][0]["title"] == "Morning meditation"
+
+    @pytest.mark.anyio
+    async def test_all_filters_forwarded(self, tools, api):
+        api.get.return_value = {"items": [], "count": 0}
+        await tools["list_routines"](
+            domain_id=VALID_UUID,
+            status="active",
+            frequency="daily",
+            streak_broken=True,
+        )
+        call_params = api.get.call_args[1]["params"]
+        assert call_params["domain_id"] == VALID_UUID
+        assert call_params["status"] == "active"
+        assert call_params["frequency"] == "daily"
+        assert call_params["streak_broken"] is True
+
+    @pytest.mark.anyio
+    async def test_invalid_status_filter(self, tools):
+        with pytest.raises(InputValidationError, match="status"):
+            await tools["list_routines"](status="bogus")
+
+    @pytest.mark.anyio
+    async def test_invalid_frequency_filter(self, tools):
+        with pytest.raises(InputValidationError, match="frequency"):
+            await tools["list_routines"](frequency="bogus")

--- a/mcp/tools/routines.py
+++ b/mcp/tools/routines.py
@@ -57,12 +57,15 @@ def register(mcp, api) -> None:
         status: str | None = None,
         frequency: str | None = None,
         streak_broken: bool | None = None,
-    ) -> list:
+    ) -> dict:
         """List routines with optional filters.
 
         Filter by domain, status (active, paused, retired), frequency,
         or streak_broken=true to find active routines that have lost their
         streak. All filters combine with AND logic.
+
+        Returns a `RoutineListResponse` envelope: ``{"items": [...], "count": N}``.
+        ``items`` is the routine list; ``count`` is the total matching the filters.
         """
         validate_uuid(domain_id, "domain_id")
         validate_enum(status, "status", ROUTINE_STATUSES)


### PR DESCRIPTION
## Verification

- `ruff check mcp/` — ✅ Pass (All checks passed!)
- `pytest tests/` (from `mcp/`, `PYTHONPATH=.`) — ✅ Pass (138 passed; baseline 133, +5 from new `TestListRoutines`)
- Migration applied locally on brain3-dev: N/A (MCP-only annotation/test change, no schema impact)
- Postgres-backed test confirmed: N/A (mock-based shim test)
- Gating brain3 PR merged on develop: ✅ Yes — `797c53d` `feat(routines): wrap list endpoint in RoutineListResponse envelope (#175)` (merge `59b0fbe`)

Ran locally against brain3-mcp develop HEAD `64ba8f8` immediately before opening this PR.

## Summary

Mirrors the brain3 #175 envelope through the MCP shim. `list_routines` now returns the `RoutineListResponse` envelope (`{items, count}`) end-to-end instead of the bare list it inherited from the pre-#175 API contract. Same pattern as the just-merged habits envelope mirror (#70 closing brain3-mcp #61).

The fix is the standard Packet 1 universal-defect resolution: change the return annotation so FastMCP's structured-output schema generation reflects the runtime dict, and document the envelope keys in the tool description so Claude parses the response correctly on first call. No new behavior — the MCP shim already passes the API response through verbatim, which is now a dict instead of a list.

## Changes

- `mcp/tools/routines.py` — `list_routines` return annotation changed from `-> list` to `-> dict`. Docstring extended with one paragraph documenting the `{"items": [...], "count": N}` envelope shape so Claude has schema-level guidance for the new contract. Body unchanged. **Note:** `list_routine_schedules` (line 192) is also annotated `-> list` but operates on a different endpoint (`/api/routines/{id}/schedules`) which brain3 #175 did not touch — left as-is per "log it, don't fix it" and one-issue-per-PR scoping.
- `mcp/tests/test_routines.py` — new file (no prior test file existed for this module). `TestListRoutines` class with five cases:
  1. `test_no_filters_empty_envelope` — bare call returns `{"items": [], "count": 0}`, asserts envelope round-trips and the API is hit with `params=None`.
  2. `test_envelope_items_passed_through` — populated envelope returns through the shim with both `items` length and `count` preserved (N≥2 case per Packet 1 §10 follow-up #3).
  3. `test_all_filters_forwarded` — `domain_id`, `status`, `frequency`, `streak_broken` all reach the underlying `api.get` call's params dict.
  4. `test_invalid_status_filter` — `status=\"bogus\"` raises `InputValidationError` before any HTTP call.
  5. `test_invalid_frequency_filter` — same for `frequency=\"bogus\"`.

  Mocks throughout use the new envelope shape, avoiding the test-mock-vs-reality drift documented in Packet 1 §2.10.

## How to Verify

1. Check out `feature/Routines-env-mcp-list-envelope`.
2. `cd mcp && PYTHONPATH=. pytest tests/ -v` — expect 138 passed.
3. Focused run: `pytest tests/test_routines.py -v` — expect 5 passed.
4. Lint: `ruff check mcp/` — expect clean.

## Deviations

None against the spec or issue intent. Minor scope note: the issue's Suggested Fix references updating existing `test_routines.py` mocks; that file did not exist (no prior test coverage for the routines module). New `test_routines.py` created with envelope-shape mocks from the start, matching the issue's intent.

`list_routine_schedules` is also annotated `-> list` and was noticed during this work — not changed in this PR because (a) the brain3 schedules endpoint contract wasn't part of #175, (b) one-issue-per-PR scoping. If the schedules endpoint should also adopt an envelope, that's a separate finding for a separate ticket.

## Acceptance Checklist

- [x] `list_routines` return annotation is `-> dict`
- [x] Tool description mentions the `{items, count}` envelope keys
- [x] Test mocks for `list_routines` use the envelope shape
- [x] At least one test asserts `result[\"items\"]` / `result[\"count\"]` access patterns (N≥2 items case included)
- [x] Filter validation tests preserved; new tests added for filter forwarding
- [x] Full test suite passes locally (138 passed)
- [x] `ruff check mcp/` clean

Closes #62