### PR TITLE
[2B-Bug-01]: Update list_notifications tool annotation and test mocks to items+count envelope

### DIFF
--- a/mcp/tests/test_notifications.py
+++ b/mcp/tests/test_notifications.py
@@ -186,16 +186,32 @@ class TestGetNotification:
 class TestListNotifications:
 
     @pytest.mark.anyio
-    async def test_no_filters(self, tools, api):
-        api.get.return_value = []
+    async def test_no_filters_empty_envelope(self, tools, api):
+        api.get.return_value = {"items": [], "count": 0}
         result = await tools["list_notifications"]()
-        assert result == []
+        assert result == {"items": [], "count": 0}
+        assert result["items"] == []
+        assert result["count"] == 0
         api.get.assert_called_once_with("/api/notifications/", params=None)
 
     @pytest.mark.anyio
+    async def test_envelope_items_passed_through(self, tools, api):
+        api.get.return_value = {
+            "items": [
+                {"id": VALID_UUID, "status": "pending"},
+                {"id": VALID_UUID_2, "status": "delivered"},
+            ],
+            "count": 2,
+        }
+        result = await tools["list_notifications"]()
+        assert result["count"] == 2
+        assert len(result["items"]) == 2
+        assert result["items"][0]["status"] == "pending"
+
+    @pytest.mark.anyio
     async def test_all_filters(self, tools, api):
-        api.get.return_value = [{"id": VALID_UUID}]
-        await tools["list_notifications"](
+        api.get.return_value = {"items": [{"id": VALID_UUID}], "count": 1}
+        result = await tools["list_notifications"](
             notification_type="habit_nudge",
             status="pending",
             delivery_type="notification",
@@ -207,6 +223,8 @@ class TestListNotifications:
             has_response=False,
             rule_id=VALID_UUID_2,
         )
+        assert result["count"] == 1
+        assert result["items"][0]["id"] == VALID_UUID
         call_params = api.get.call_args[1]["params"]
         assert call_params["notification_type"] == "habit_nudge"
         assert call_params["status"] == "pending"

--- a/mcp/tools/notifications.py
+++ b/mcp/tools/notifications.py
@@ -101,16 +101,22 @@ def register(mcp, api) -> None:
         scheduled_before: str | None = None,
         has_response: bool | None = None,
         rule_id: str | None = None,
-    ) -> list:
+    ) -> dict:
         """Browse notifications with composable filters.
 
         All filter parameters are optional and combine with AND logic.
         Results are ordered by scheduled_at descending (newest first).
 
+        Returns a `NotificationListResponse` envelope:
+        ``{"items": [...], "count": N}``. Access notifications via
+        ``response["items"]``; ``response["count"]`` gives the total
+        matching the filters.
+
         Common patterns:
         - Pending queue: status="pending"
         - Delivered but unanswered: status="delivered"
-        - Silence tracking: has_response=false with a scheduled_after window
+        - Silence tracking: status="expired" + has_response=false
+          (or has_response=false with a scheduled_after window)
         - By origin: scheduled_by="claude" or scheduled_by="rule"
         - By target: target_entity_type + target_entity_id
         """


### PR DESCRIPTION
## Verification

- `ruff check mcp/` — ✅ Pass (All checks passed!)
- `pytest tests/` (from `mcp/`, `PYTHONPATH=.`) — ✅ Pass (139 passed; baseline 138, +1 from new `test_envelope_items_passed_through`; two existing `TestListNotifications` cases updated in place)
- Migration applied locally on brain3-dev: N/A (MCP-only annotation/test change, no schema impact)
- Postgres-backed test confirmed: N/A (mock-based shim test)
- Gating brain3 PR merged on develop: ✅ Yes — `36c2af3` `feat(notifications): wrap list endpoint in NotificationListResponse envelope (#176)` (merge `5bdbb6c`)

Ran locally against brain3-mcp develop HEAD `88c51d9` immediately before opening this PR.

## Summary

Mirrors the brain3 #176 envelope through the MCP shim. `list_notifications` now returns the `NotificationListResponse` envelope (`{items, count}`) end-to-end instead of the bare list it inherited from the pre-#176 API contract. This is the third Wave 3 envelope mirror (after #61/PR70 habits and #62/PR71 routines) and the highest-volume list endpoint — Stellan flagged it as the most acute latent observable bug for non-Claude consumers reading the unstructured channel.

Same Packet 1 universal-defect resolution: change the return annotation so FastMCP's structured-output schema generation reflects the runtime dict, and document the envelope keys in the tool description per [B-6] v2 Amendment 24 so Claude parses the response correctly on first call. No behavior change in the body — the call already passes the API response through verbatim.

## Changes

- `mcp/tools/notifications.py` — `list_notifications` return annotation changed from `-> list` to `-> dict`. Docstring extended with the Amendment 24 envelope guidance (`{"items": [...], "count": N}` access via `response["items"]` / `response["count"]`). Refined the silence-tracking common-pattern bullet to match the spec wording (`status="expired" + has_response=false`). Body unchanged.
- `mcp/tests/test_notifications.py` — `TestListNotifications` updated to envelope shape:
  1. `test_no_filters` → `test_no_filters_empty_envelope` — mock and assertion both use `{"items": [], "count": 0}`; existing `params=None` call assertion preserved.
  2. NEW `test_envelope_items_passed_through` — N=2 populated envelope round-trips through the shim with both `items` length and `count` preserved (the Packet 1 §10 follow-up #3 N≥2 case).
  3. `test_all_filters` — mock updated to `{"items": [{"id": VALID_UUID}], "count": 1}`; result assertions added for `count` and `items[0]["id"]`; all existing 10-filter forwarding assertions preserved.
  4. `test_invalid_status_filter` / `test_invalid_notification_type_filter` — unchanged (no mock changes needed; pre-HTTP validation paths).

  Mocks now match the real API contract, avoiding the test-mock-vs-reality drift documented in Packet 1 §2.10.

## How to Verify

1. Check out `feature/B-6-env-notifications-list-envelope`.
2. `cd mcp && PYTHONPATH=. pytest tests/ -v` — expect 139 passed.
3. Focused run: `pytest tests/test_notifications.py -v -k TestListNotifications` — expect 5 passed (was 4 pre-fix).
4. Lint: `ruff check mcp/` — expect clean.

## Deviations

None against spec/issue intent. Wider filter surface than #61/#62 — handled by keeping all 10-filter forwarding assertions intact while updating mocks underneath. No changes to the four other notification tools' tests; their mocks were already correct (single-object returns, not list endpoints).

## Acceptance Checklist

- [x] `list_notifications` return annotation is `-> dict`
- [x] Tool description mentions the `{items, count}` envelope keys (per [B-6] v2 Amendment 24)
- [x] Test mocks for `list_notifications` use the envelope shape
- [x] At least one test asserts `result["items"]` / `result["count"]` access patterns (N≥2 items case included)
- [x] Filter validation tests preserved; 10-filter forwarding coverage preserved
- [x] Full test suite passes locally (139 passed)
- [x] `ruff check mcp/` clean

Closes #63