### PR TITLE
[2F-Bug-02]: Update list_rules tool annotation and test mocks to items+count envelope

### DIFF
--- a/mcp/tests/test_rules.py
+++ b/mcp/tests/test_rules.py
@@ -244,21 +244,40 @@ class TestCreateRule:
 class TestListRules:
 
     @pytest.mark.anyio
-    async def test_no_filters(self, tools, api):
-        api.get.return_value = []
+    async def test_no_filters_empty_envelope(self, tools, api):
+        api.get.return_value = {"items": [], "count": 0}
         result = await tools["list_rules"]()
-        assert result == []
+        assert result == {"items": [], "count": 0}
+        assert result["items"] == []
+        assert result["count"] == 0
         api.get.assert_called_once_with("/api/rules/", params=None)
 
     @pytest.mark.anyio
+    async def test_envelope_items_passed_through(self, tools, api):
+        api.get.return_value = {
+            "items": [
+                {"id": VALID_UUID, "name": "Skip alert"},
+                {"id": VALID_UUID_2, "name": "Silence alert"},
+            ],
+            "count": 2,
+        }
+        result = await tools["list_rules"]()
+        assert result["count"] == 2
+        assert len(result["items"]) == 2
+        assert result["items"][0]["name"] == "Skip alert"
+        assert result["items"][1]["id"] == VALID_UUID_2
+
+    @pytest.mark.anyio
     async def test_all_filters(self, tools, api):
-        api.get.return_value = [{"id": VALID_UUID}]
-        await tools["list_rules"](
+        api.get.return_value = {"items": [{"id": VALID_UUID}], "count": 1}
+        result = await tools["list_rules"](
             entity_type="habit",
             enabled=True,
             notification_type="habit_nudge",
             entity_id=VALID_UUID,
         )
+        assert result["count"] == 1
+        assert result["items"][0]["id"] == VALID_UUID
         call_params = api.get.call_args[1]["params"]
         assert call_params["entity_type"] == "habit"
         assert call_params["enabled"] is True

--- a/mcp/tools/rules.py
+++ b/mcp/tools/rules.py
@@ -86,11 +86,16 @@ def register(mcp, api) -> None:
         enabled: bool | None = None,
         notification_type: str | None = None,
         entity_id: str | None = None,
-    ) -> list:
+    ) -> dict:
         """List rules with optional filters.
 
         Use to review what rules exist and their current state. All filter
         parameters are optional and combine with AND logic.
+
+        Returns a `RuleListResponse` envelope:
+        ``{"items": [...], "count": N}``. Access rules via
+        ``response["items"]``; ``response["count"]`` gives the total
+        matching the filters.
 
         Common patterns:
         - Review active rules: enabled=true


### PR DESCRIPTION
## Verification

- `ruff check mcp/` — ✅ Pass (All checks passed!)
- `pytest tests/` (from `mcp/`, `PYTHONPATH=.`) — ✅ Pass (140 passed; baseline 139, +1 from new `test_envelope_items_passed_through`; two existing `TestListRules` cases updated in place)
- Migration applied locally on brain3-dev: N/A (MCP-only annotation/test change, no schema impact)
- Postgres-backed test confirmed: N/A (mock-based shim test)
- Gating brain3 PR merged on develop: ✅ Yes — `c0ff139` `feat(rules): wrap list endpoint in RuleListResponse envelope (#177)` (merge `c3d495e`)

Ran locally against brain3-mcp develop HEAD `e23e587` immediately before opening this PR.

## Summary

Mirrors the brain3 #177 envelope through the MCP shim. `list_rules` now returns the `RuleListResponse` envelope (`{items, count}`) end-to-end instead of the bare list it inherited from the pre-#177 API contract. Fourth Wave 3 envelope mirror (after #61/PR70 habits, #62/PR71 routines, #63/PR72 notifications).

Same Packet 1 universal-defect resolution: change the return annotation so FastMCP's structured-output schema generation reflects the runtime dict, and document the envelope keys in the tool description per [2F-05] v2 Amendment 22 so Claude parses the response correctly on first call. No behavior change in the body — the call already passes the API response through verbatim.

## Changes

- `mcp/tools/rules.py` — `list_rules` return annotation changed from `-> list` to `-> dict`. Docstring extended with the Amendment 22 envelope guidance (`{"items": [...], "count": N}` access via `response["items"]` / `response["count"]`). Body unchanged.
- `mcp/tests/test_rules.py` — `TestListRules` updated to envelope shape:
  1. `test_no_filters` → `test_no_filters_empty_envelope` — mock and assertion both use `{"items": [], "count": 0}`; existing `params=None` call assertion preserved.
  2. NEW `test_envelope_items_passed_through` — N=2 populated envelope round-trips through the shim with both `items` length and `count` preserved (the Packet 1 §10 follow-up #3 N≥2 case).
  3. `test_all_filters` — mock updated to `{"items": [{"id": VALID_UUID}], "count": 1}`; result assertions added for `count` and `items[0]["id"]`; all existing 4-filter forwarding assertions preserved.
  4. Three `test_invalid_*_filter` cases — unchanged (pre-HTTP validation paths, no mock impact).

  Mocks now match the real API contract, avoiding the test-mock-vs-reality drift documented in Packet 1 §2.10.

## How to Verify

1. Check out `feature/2F-05-env-rules-list-envelope`.
2. `cd mcp && PYTHONPATH=. pytest tests/ -v` — expect 140 passed.
3. Focused run: `pytest tests/test_rules.py -v -k TestListRules` — expect 6 passed (was 5 pre-fix).
4. Lint: `ruff check mcp/` — expect clean.

## Deviations

None against spec/issue intent. Spec §Amendment 22 calls out both the `list_rules` envelope (this PR) and the `evaluate_rules` envelope (handled separately in Wave 3 ticket #65 per the brief); this PR is scoped to the list endpoint only, consistent with one-issue-per-PR.

## Acceptance Checklist

- [x] `list_rules` return annotation is `-> dict`
- [x] Tool description mentions the `{items, count}` envelope keys (per [2F-05] v2 Amendment 22)
- [x] Test mocks for `list_rules` use the envelope shape
- [x] At least one test asserts `result["items"]` / `result["count"]` access patterns (N≥2 items case included)
- [x] Filter validation tests preserved; 4-filter forwarding coverage preserved
- [x] Full test suite passes locally (140 passed)
- [x] `ruff check mcp/` clean

Closes #64