### PR TITLE
[2F-Bug-03]: Update evaluate_rules tool description and test mocks to summary+results envelope

### DIFF
--- a/mcp/tests/test_rules.py
+++ b/mcp/tests/test_rules.py
@@ -440,12 +440,146 @@ class TestEvaluateRules:
     @pytest.mark.anyio
     async def test_happy_path(self, tools, api):
         api.post.return_value = {
-            "evaluated": 5, "fired": 2, "skipped": 3, "results": [],
+            "summary": {
+                "total_rules_evaluated": 5,
+                "fired": 2,
+                "cooldown": 1,
+                "condition_not_met": 2,
+                "no_matching_entities": 0,
+                "error": 0,
+                "total_notifications_created": 2,
+                "evaluated_at": "2026-04-19T12:00:00Z",
+            },
+            "results": [],
         }
         result = await tools["evaluate_rules"]()
-        assert result["evaluated"] == 5
-        assert result["fired"] == 2
+        assert result["summary"]["total_rules_evaluated"] == 5
+        assert result["summary"]["fired"] == 2
+        assert result["summary"]["cooldown"] == 1
+        assert result["summary"]["total_notifications_created"] == 2
+        assert result["summary"]["evaluated_at"] == "2026-04-19T12:00:00Z"
+        assert result["results"] == []
         api.post.assert_called_once_with("/api/rules/evaluate")
+
+    @pytest.mark.anyio
+    async def test_envelope_empty_results(self, tools, api):
+        api.post.return_value = {
+            "summary": {
+                "total_rules_evaluated": 0,
+                "fired": 0,
+                "cooldown": 0,
+                "condition_not_met": 0,
+                "no_matching_entities": 0,
+                "error": 0,
+                "total_notifications_created": 0,
+                "evaluated_at": "2026-04-19T12:00:00Z",
+            },
+            "results": [],
+        }
+        result = await tools["evaluate_rules"]()
+        assert result["summary"]["total_rules_evaluated"] == 0
+        assert result["results"] == []
+
+    @pytest.mark.anyio
+    async def test_envelope_results_passed_through(self, tools, api):
+        api.post.return_value = {
+            "summary": {
+                "total_rules_evaluated": 2,
+                "fired": 1,
+                "cooldown": 0,
+                "condition_not_met": 1,
+                "no_matching_entities": 0,
+                "error": 0,
+                "total_notifications_created": 1,
+                "evaluated_at": "2026-04-19T12:00:00Z",
+            },
+            "results": [
+                {
+                    "rule_id": VALID_UUID,
+                    "rule_name": "Skip alert",
+                    "fired": True,
+                    "reason": "fired",
+                    "notifications_created": 1,
+                    "entities_evaluated": 1,
+                },
+                {
+                    "rule_id": VALID_UUID_2,
+                    "rule_name": "Silence alert",
+                    "fired": False,
+                    "reason": "condition_not_met",
+                    "notifications_created": 0,
+                    "entities_evaluated": 1,
+                },
+            ],
+        }
+        result = await tools["evaluate_rules"]()
+        assert result["summary"]["fired"] == 1
+        assert len(result["results"]) == 2
+        assert result["results"][0]["rule_id"] == VALID_UUID
+        assert result["results"][0]["fired"] is True
+        assert result["results"][1]["reason"] == "condition_not_met"
+
+    @pytest.mark.anyio
+    async def test_envelope_preserves_summary_as_nested_object_via_fastmcp(
+        self, api,
+    ):
+        """Drive the tool through FastMCP.call_tool and confirm the summary
+        is serialized as a nested JSON object, not a stringified blob.
+
+        Covers the cardinal concern from Wave 3 #65: the `summary` field
+        must remain a parseable object end-to-end through the MCP layer.
+        A single content block (no list iteration) carries the envelope,
+        and JSON-parsing that block yields a nested dict with `summary` as
+        an object — never as a pre-stringified inner blob.
+        """
+        import json
+
+        mcp = FastMCP("test-envelope")
+        register(mcp, api)
+
+        summary_payload = {
+            "total_rules_evaluated": 3,
+            "fired": 1,
+            "cooldown": 1,
+            "condition_not_met": 1,
+            "no_matching_entities": 0,
+            "error": 0,
+            "total_notifications_created": 1,
+            "evaluated_at": "2026-04-19T12:00:00Z",
+        }
+        results_payload = [
+            {
+                "rule_id": VALID_UUID,
+                "rule_name": "Skip alert",
+                "fired": True,
+                "reason": "fired",
+                "notifications_created": 1,
+                "entities_evaluated": 1,
+            },
+        ]
+        api.post.return_value = {
+            "summary": summary_payload,
+            "results": results_payload,
+        }
+
+        content_blocks = await mcp.call_tool("evaluate_rules", {})
+
+        assert len(content_blocks) == 1, (
+            "envelope must produce a single content block — a list return "
+            "would trigger FastMCP list-iteration (P1.1)"
+        )
+        text_block = content_blocks[0]
+        assert text_block.type == "text"
+
+        parsed = json.loads(text_block.text)
+        assert isinstance(parsed, dict)
+        assert set(parsed.keys()) == {"summary", "results"}
+        assert isinstance(parsed["summary"], dict), (
+            "summary must be a nested JSON object, not a stringified blob"
+        )
+        assert parsed["summary"] == summary_payload
+        assert isinstance(parsed["results"], list)
+        assert parsed["results"] == results_payload
 
 
 # ---------------------------------------------------------------------------

--- a/mcp/tools/rules.py
+++ b/mcp/tools/rules.py
@@ -194,8 +194,20 @@ def register(mcp, api) -> None:
         """Evaluate all enabled rules now.
 
         Checks each rule's condition against current BRAIN data, respects
-        cooldowns, and creates notifications for rules that fire. Returns
-        a summary of what fired and what was skipped.
+        cooldowns, and creates notifications for rules that fire.
+
+        Returns a `RuleEvaluationRunResponse` envelope:
+        ``{"summary": {...}, "results": [...]}``.
+
+        ``response["summary"]`` is a nested object with the run-level
+        totals: ``total_rules_evaluated``, per-reason counts (``fired``,
+        ``cooldown``, ``condition_not_met``, ``no_matching_entities``,
+        ``error``), ``total_notifications_created``, and ``evaluated_at``
+        (ISO8601 UTC).
+
+        ``response["results"]`` is a list of per-rule outcomes with
+        ``rule_id``, ``rule_name``, ``fired``, ``reason``,
+        ``notifications_created``, ``entities_evaluated``.
 
         The scheduler calls this automatically, but you can trigger it
         manually during a session to check rule behavior or after making


### PR DESCRIPTION
## Verification

- `pytest -v` (from `mcp/`) — ✅ Pass (143 passed)
- `ruff check .` (from `mcp/`) — ✅ Pass (All checks passed!)
- Annotation check: `evaluate_rules() -> dict` matches the new brain3 envelope — ✅
- Envelope summary preserved as nested JSON object (not stringified blob) — ✅ (covered by `test_envelope_preserves_summary_as_nested_object_via_fastmcp`)

Ran locally against brain3-mcp develop HEAD at `87c4517` immediately before opening this PR.

## Gate Confirmation

brain3 PR `[2F-Bug-04]` (#178) merged on brain3 develop at `6a0fd19` (merge commit `3b2491a`) — verified via `git log origin/develop --oneline` on brain3. The paired API envelope (`RuleEvaluationRunResponse {summary, results}`) is live on develop.

## Summary

Mirror the brain3 #178 `RuleEvaluationRunResponse` envelope through the MCP shim. After the paired brain3 PR landed, the `evaluate_rules` tool already returned the API response directly — the annotation `-> dict` was already correct. The two remaining gaps closed here:

1. The tool docstring did not mention the envelope keys, so Claude had no schema-level guidance on first call.
2. `TestEvaluateRules.test_happy_path` mocked a divergent `{evaluated, fired, skipped, results}` shape that never shipped, drifting from the canonical shape.

Also added targeted coverage for the cardinal concern of this ticket: the nested `summary` object must serialize through the MCP layer as a parseable JSON object, never as a pre-stringified inner blob.

## Changes

- **`mcp/tools/rules.py`** — Expanded the `evaluate_rules` docstring to describe the `{summary, results}` envelope, enumerate the `summary` sub-fields (`total_rules_evaluated`, per-reason counts, `total_notifications_created`, `evaluated_at`), and the `results` shape.
- **`mcp/tests/test_rules.py`** — Replaced the stale `test_happy_path` mock with the canonical envelope shape and realigned assertions to read `result["summary"][...]` / `result["results"]`. Added three new tests in `TestEvaluateRules`:
  - `test_envelope_empty_results` — zero-rule path.
  - `test_envelope_results_passed_through` — N=2-rule path, asserts envelope integrity and per-result field pass-through.
  - `test_envelope_preserves_summary_as_nested_object_via_fastmcp` — drives the tool through `FastMCP.call_tool()`, asserts a single content block (no P1.1 list iteration), JSON-parses the text payload, and confirms `summary` is a nested `dict` — not a stringified blob.

## How to Verify

From `brain3-mcp/mcp/`:

```bash
pytest -v tests/test_rules.py::TestEvaluateRules
pytest -v
ruff check .
```

Live-API spot-check against a brain3 dev instance:

```python
# Inside a Claude session with 0 enabled rules:
evaluate_rules()
# → response["summary"]["total_rules_evaluated"] == 0
# → response["results"] == []

# With 1+ enabled rules:
evaluate_rules()
# → response["summary"] is a dict with all per-reason counts
# → response["summary"]["evaluated_at"] is an ISO8601 string
# → response["results"] is a list of per-rule outcomes
```

## Deviations

None. Docstring mirrors the `list_rules` envelope convention introduced in sister PR #73, scaled up for the nested `summary` object. Test coverage mirrors `TestListRules` plus adds the FastMCP-level serialization assertion the brief called out as higher-complexity than list envelopes.

## Test Results

```
$ pytest -v
============================= 143 passed in 2.26s =============================

$ ruff check .
All checks passed!
```

## Acceptance Checklist

- [x] `evaluate_rules` tool docstring mentions the envelope keys (`summary` with sub-fields + `results`).
- [x] Tool annotation `-> dict` verified against the new brain3 contract.
- [x] `TestEvaluateRules.test_happy_path` mock updated to the canonical `{summary, results}` shape.
- [x] Assertions realigned to read `result["summary"][...]`, `result["summary"]["fired"]`, `result["summary"]["total_rules_evaluated"]`, `result["results"]`.
- [x] Added FastMCP-level serialization test confirming `summary` stays a nested JSON object end-to-end (Wave 3 cardinal concern).
- [x] Full verification suite passes (pytest + ruff).
- [x] Gate confirmed: brain3 #178 merged on develop at `6a0fd19`.

Closes #65