### PR TITLE
[2A-Enh-01]: Update get_habit tool description for effective_graduation_params

### DIFF
--- a/mcp/tests/test_habits.py
+++ b/mcp/tests/test_habits.py
@@ -172,6 +172,69 @@ class TestListHabits:
 
 
 # ---------------------------------------------------------------------------
+# get_habit — effective_graduation_params pass-through
+# ---------------------------------------------------------------------------
+
+
+class TestGetHabitEffectiveGraduationParams:
+    """[2A-Enh-01] get_habit must pass ``effective_graduation_params`` through.
+
+    The MCP shim is a pass-through over GET /api/habits/{id}, so these tests
+    assert the shim forwards the nested composite field intact — matching the
+    real API contract surfaced by HabitDetailResponse in brain3.
+    """
+
+    @pytest.mark.anyio
+    async def test_get_habit_returns_effective_graduation_params_friction_default(
+        self, tools, api,
+    ):
+        api.get.return_value = {
+            "id": VALID_UUID,
+            "title": "Floss",
+            "graduation_window": None,
+            "graduation_target": None,
+            "graduation_threshold": None,
+            "friction_score": 3,
+            "effective_graduation_params": {
+                "window_days": 45,
+                "target_rate": 0.85,
+                "threshold_days": 45,
+                "source": "friction_default",
+            },
+        }
+        result = await tools["get_habit"](habit_id=VALID_UUID)
+        api.get.assert_called_once_with(f"/api/habits/{VALID_UUID}")
+        assert result["effective_graduation_params"] == {
+            "window_days": 45,
+            "target_rate": 0.85,
+            "threshold_days": 45,
+            "source": "friction_default",
+        }
+
+    @pytest.mark.anyio
+    async def test_get_habit_returns_effective_graduation_params_override(
+        self, tools, api,
+    ):
+        api.get.return_value = {
+            "id": VALID_UUID,
+            "title": "Floss",
+            "graduation_window": 100,
+            "graduation_target": 0.70,
+            "graduation_threshold": 100,
+            "friction_score": 1,
+            "effective_graduation_params": {
+                "window_days": 100,
+                "target_rate": 0.70,
+                "threshold_days": 100,
+                "source": "override",
+            },
+        }
+        result = await tools["get_habit"](habit_id=VALID_UUID)
+        assert result["effective_graduation_params"]["source"] == "override"
+        assert result["effective_graduation_params"]["window_days"] == 100
+
+
+# ---------------------------------------------------------------------------
 # [MCP-BUG-01] Structured-detail error envelope — regression coverage
 # ---------------------------------------------------------------------------
 

--- a/mcp/tools/habits.py
+++ b/mcp/tools/habits.py
@@ -80,11 +80,28 @@ def register(mcp, api) -> None:
 
     @mcp.tool()
     async def get_habit(habit_id: str) -> dict:
-        """Get a habit with its parent routine info.
+        """Get a single habit with full detail.
 
         Returns habit details including scaffolding status, completion stats,
-        and the parent routine (if linked). Use this to check on a specific
-        habit's progress or configuration.
+        the parent routine (if linked), and ``effective_graduation_params`` —
+        the resolved graduation criteria after friction-tier defaults and
+        re-scaffold tightening are applied. Use this when you need the
+        complete habit view for display or evaluation.
+
+        The response includes the bare override columns
+        (``graduation_window``, ``graduation_target``, ``graduation_threshold``)
+        which reflect only what was explicitly set on the habit and may be
+        ``null``. For the actual values the graduation engine will use,
+        read ``effective_graduation_params`` instead.
+
+        ``effective_graduation_params`` is a nested object shaped:
+        ``{"window_days": int, "target_rate": float, "threshold_days": int,
+        "source": "override" | "friction_default"}``.
+        ``source`` is ``"override"`` when any of the three bare override
+        columns is non-null (overrides win per-field, others fall back to
+        friction defaults) and ``"friction_default"`` when all three are
+        null (values come from the friction-score tier). The field is
+        computed at serialization — it cannot be set on create/update.
         """
         validate_uuid(habit_id, "habit_id")
         return await api.get(f"/api/habits/{habit_id}")


### PR DESCRIPTION
## Verification

- `pytest -v` (from `mcp/`) — ✅ Pass (145 passed)
- `ruff check .` (from `mcp/`) — ✅ Pass (All checks passed!)
- MCP layer remains pass-through (no shim-body logic changes) — ✅
- Tool test mock for `get_habit` includes `effective_graduation_params` matching the real API contract from brain3 `HabitDetailResponse` — ✅

Ran locally against brain3-mcp develop HEAD at `eb098aa` immediately before opening this PR.

## Gate Confirmation

Both upstream brain3 PRs visible on brain3 `develop` (verified via `git log origin/develop --oneline` on brain3):

- brain3 #181 — `477fc6e feat(habits): add effective_graduation_params composite to HabitResponse (#181)`
- brain3 #182 — `f39cb71 fix(habits): remove scalar defaults on graduation override columns (#182)` and `b87f089 test(graduation): add D1 regression coverage for friction-aware resolver (#182)`

Per the Wave 3 brief, #66 gates on #181 (transitively requires #182). Both are merged — proceeding.

## Summary

Surface the new `effective_graduation_params` composite field from brain3 `HabitDetailResponse` (shipped in brain3 #181) through the `get_habit` MCP tool description, and align the tool-test mock with the real API contract. The MCP layer itself is already pass-through over `GET /api/habits/{id}`, so this is a description-and-test-mock change only — no shim-body logic changes.

## Changes

- **`mcp/tools/habits.py`** — Expanded the `get_habit` tool docstring. It now names the new nested field, describes its shape (`window_days`, `target_rate`, `threshold_days`, `source`), explains the `"override" | "friction_default"` source semantics (override wins per-field when any of the three bare override columns is non-null; otherwise values come from the friction-score tier), and calls out that the field is computed at serialization time (read-only, not settable on create/update). Also clarifies the relationship between `effective_graduation_params` and the bare `graduation_window` / `graduation_target` / `graduation_threshold` override columns so Claude reaches for the right field depending on whether it wants the resolved value or the raw override.
- **`mcp/tests/test_habits.py`** — Added `TestGetHabitEffectiveGraduationParams` with two tests covering both source variants:
  - `test_get_habit_returns_effective_graduation_params_friction_default` — no overrides, `friction_score=3` → `source="friction_default"`, values from the friction-3 tier.
  - `test_get_habit_returns_effective_graduation_params_override` — all three override columns set → `source="override"`, values come from overrides.

  Both tests assert the MCP shim passes the nested composite object through intact. The mock shape mirrors the canonical response produced by `HabitResponse.effective_graduation_params` in brain3 (friction-3 tier: `{45, 0.85, 45}`; override sample: `{100, 0.70, 100}`).

## How to Verify

From `brain3-mcp/mcp/`:

```bash
pytest -v tests/test_habits.py::TestGetHabitEffectiveGraduationParams
pytest -v
ruff check .
```

## Acceptance Checklist

- [x] `get_habit` tool description mentions `effective_graduation_params` nested field with shape and purpose
- [x] Tool test mock includes `effective_graduation_params` matching the real API shape
- [x] MCP layer remains pass-through; no shim-body logic changes

## Deviations

None. Description text closely follows the `[A-9]` v2 spec recommendation (Amendment 08) and extends it slightly to spell out the per-field override behavior and the computed/read-only nature of the field, so Claude has complete schema-level guidance on first call.

Closes #66

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)