### PR TITLE
[2A-Enh-02]: Update create_habit, update_habit, get_habit tool parameters and descriptions for accountable_since rename

### DIFF
--- a/mcp/tests/test_habits.py
+++ b/mcp/tests/test_habits.py
@@ -235,6 +235,45 @@ class TestGetHabitEffectiveGraduationParams:
 
 
 # ---------------------------------------------------------------------------
+# [A-9-accountable-since] accountable_since rename — pass-through coverage
+# ---------------------------------------------------------------------------
+
+class TestAccountableSinceRename:
+    """D2 rename: MCP tools accept ``accountable_since`` and forward it verbatim."""
+
+    @pytest.mark.anyio
+    async def test_create_habit_accountable_since_passed_through(
+        self, tools, api,
+    ):
+        api.post.return_value = {"id": VALID_UUID}
+        await tools["create_habit"](
+            title="Floss", frequency="daily", accountable_since="2026-04-10",
+        )
+        body = api.post.call_args[1]["json"]
+        assert body["accountable_since"] == "2026-04-10"
+
+    @pytest.mark.anyio
+    async def test_create_habit_accountable_since_omitted_when_none(
+        self, tools, api,
+    ):
+        api.post.return_value = {"id": VALID_UUID}
+        await tools["create_habit"](title="Floss", frequency="daily")
+        body = api.post.call_args[1]["json"]
+        assert "accountable_since" not in body
+
+    @pytest.mark.anyio
+    async def test_update_habit_accountable_since_passed_through(
+        self, tools, api,
+    ):
+        api.patch.return_value = {"id": VALID_UUID}
+        await tools["update_habit"](
+            habit_id=VALID_UUID, accountable_since="2026-04-10",
+        )
+        body = api.patch.call_args[1]["json"]
+        assert body["accountable_since"] == "2026-04-10"
+
+
+# ---------------------------------------------------------------------------
 # [MCP-BUG-01] Structured-detail error envelope — regression coverage
 # ---------------------------------------------------------------------------
 

--- a/mcp/tools/habits.py
+++ b/mcp/tools/habits.py
@@ -26,7 +26,7 @@ def register(mcp, api) -> None:
         frequency: str | None = None,
         notification_frequency: str = "none",
         scaffolding_status: str = "tracking",
-        introduced_at: str | None = None,
+        accountable_since: str | None = None,
         graduation_window: int | None = None,
         graduation_target: float | None = None,
         graduation_threshold: int | None = None,
@@ -40,6 +40,11 @@ def register(mcp, api) -> None:
 
         Scaffolding starts at "tracking" — the user just logs completions.
         Later stages add accountability and graduation criteria.
+
+        ``accountable_since`` is the date the habit becomes accountable
+        (ISO date, YYYY-MM-DD). Auto-populated on the tracking→accountable
+        transition. Set explicitly only to backdate the accountability anchor
+        — otherwise leave it unset and let the transition stamp it.
 
         friction_score (1–5) captures how hard this habit feels to the user
         and drives graduation defaults: higher friction = longer window and
@@ -70,7 +75,7 @@ def register(mcp, api) -> None:
             "frequency": frequency,
             "notification_frequency": notification_frequency,
             "scaffolding_status": scaffolding_status,
-            "introduced_at": introduced_at,
+            "accountable_since": accountable_since,
             "graduation_window": graduation_window,
             "graduation_target": graduation_target,
             "graduation_threshold": graduation_threshold,
@@ -83,10 +88,12 @@ def register(mcp, api) -> None:
         """Get a single habit with full detail.
 
         Returns habit details including scaffolding status, completion stats,
-        the parent routine (if linked), and ``effective_graduation_params`` —
-        the resolved graduation criteria after friction-tier defaults and
-        re-scaffold tightening are applied. Use this when you need the
-        complete habit view for display or evaluation.
+        ``accountable_since`` (the date the habit entered the accountable
+        stage — null while still in tracking), the parent routine (if
+        linked), and ``effective_graduation_params`` — the resolved
+        graduation criteria after friction-tier defaults and re-scaffold
+        tightening are applied. Use this when you need the complete habit
+        view for display or evaluation.
 
         The response includes the bare override columns
         (``graduation_window``, ``graduation_target``, ``graduation_threshold``)
@@ -143,7 +150,7 @@ def register(mcp, api) -> None:
         frequency: str | None = None,
         notification_frequency: str | None = None,
         scaffolding_status: str | None = None,
-        introduced_at: str | None = None,
+        accountable_since: str | None = None,
         graduation_window: int | None = None,
         graduation_target: float | None = None,
         graduation_threshold: int | None = None,
@@ -154,6 +161,11 @@ def register(mcp, api) -> None:
         Only provided fields are changed. Use this to advance scaffolding
         status, pause/resume a habit, adjust graduation criteria, or change
         notification frequency.
+
+        ``accountable_since`` (ISO date, YYYY-MM-DD) is normally auto-populated
+        on the tracking→accountable transition. Pass it here only to backdate
+        or correct the accountability anchor; routine accountability
+        transitions do not need it set explicitly.
 
         friction_score (1–5) captures how hard this habit feels to the user
         and drives graduation defaults: higher friction = longer window and
@@ -179,7 +191,7 @@ def register(mcp, api) -> None:
             "frequency": frequency,
             "notification_frequency": notification_frequency,
             "scaffolding_status": scaffolding_status,
-            "introduced_at": introduced_at,
+            "accountable_since": accountable_since,
             "graduation_window": graduation_window,
             "graduation_target": graduation_target,
             "graduation_threshold": graduation_threshold,


### PR DESCRIPTION
## Verification

- `ruff check mcp/` — ✅ Pass (All checks passed)
- `pytest -v` — ✅ Pass (148 passed in 2.40s)
- `grep -r introduced_at` (brain3-mcp, excluding `.git`) — ✅ Zero hits
- brain3 gate (#183) merged on develop — ✅ Yes, SHA `6d36e48` (`refactor(habits): rename introduced_at to accountable_since…`)

Ran locally against brain3-mcp develop HEAD `2d40495` immediately before opening this PR.

> **Note on `ruff check .` scoping:** Running `ruff check .` from the repo root flags pre-existing F401 errors inside `.claude/worktrees/agent-*/mcp/server.py` — stale Claude Code agent-isolation worktrees from prior sessions, dated March 28. Not part of the tracked repo, untouched by this PR. Scoped ruff to `mcp/` so the evidence above reflects this change only. Filing a separate observation for repo-hygiene follow-up.

## Summary

Mirrors brain3 #183 into the MCP shim. The `introduced_at` parameter on `create_habit` / `update_habit` is renamed to `accountable_since`, and `get_habit`'s docstring is updated to document the renamed response field. Tool descriptions now explain the auto-population rule (stamped on the tracking→accountable transition) and the backdate-override intent. No shim-body logic changes — rename is pass-through.

## Changes

- `mcp/tools/habits.py` — `create_habit` and `update_habit` parameter renamed (`introduced_at` → `accountable_since`); request-body key renamed to match; docstrings updated to document the auto-populate + backdate-override semantics. `get_habit` docstring updated to list `accountable_since` alongside `effective_graduation_params` in the response shape.
- `mcp/tests/test_habits.py` — new `TestAccountableSinceRename` class with pass-through coverage (create and update), plus an omit-when-None assertion for create. Existing tests unchanged.

## How to Verify

1. Check out this branch (`feature/A-9-accountable-since-rename`).
2. `cd mcp && pytest -v` — 148 tests pass.
3. `ruff check mcp/` — clean.
4. `grep -r introduced_at .` — zero hits outside `.git`.
5. Confirm brain3#183 is merged on brain3 `develop` (SHA `6d36e48`).

## Deviations

- Added tool description language for `accountable_since` auto-population + backdate-override that isn't strictly required by the issue's acceptance criteria but was called out in the "Suggested Fix" section. Lean towards informative descriptions per brain3-mcp CLAUDE.md ("Tool Descriptions Are Written for Claude").
- Scoped `ruff check` to `mcp/` instead of `.` — rationale above (pre-existing stale agent worktrees under `.claude/`).

## Test Results

```
============================= 148 passed in 2.40s =============================
```

Ruff: `All checks passed!`

## Acceptance Checklist

- [x] `get_habit`, `create_habit`, `update_habit` tool parameters use `accountable_since` (not `introduced_at`)
- [x] Tool descriptions explain the auto-population rule and the backdate-override intent
- [x] Tool tests pass against the renamed API contract
- [x] No shim-body logic changes — rename is pass-through

Closes #67